### PR TITLE
don't use px to set background-size

### DIFF
--- a/slides/01-introduction.qmd
+++ b/slides/01-introduction.qmd
@@ -130,19 +130,25 @@ Many thanks to Julie Jung, Alison Hill, and Desirée De Leon for their role in c
 
 [bit.ly/tidymodels-workshop](http://bit.ly/tidymodels-workshop)
 
-## What is machine learning? {background-image="https://imgs.xkcd.com/comics/machine_learning.png" background-size="500px"}
+## What is machine learning?
+
+![](https://imgs.xkcd.com/comics/machine_learning.png){fig-align="center"}
 
 ::: footer
 <https://xkcd.com/1838/>
 :::
 
-## What is machine learning? {background-image="images/what_is_ml.jpg" background-size="800px"}
+## What is machine learning? 
+
+![](images/what_is_ml.jpg){fig-align="center"}
 
 ::: footer
 Illustration credit: <https://vas3k.com/blog/machine_learning/>
 :::
 
-## What is machine learning? {background-image="images/ml_illustration.jpg" background-size="800px"}
+## What is machine learning?
+
+![](images/ml_illustration.jpg){fig-align="center"}
 
 ::: footer
 Illustration credit: <https://vas3k.com/blog/machine_learning/>
@@ -182,7 +188,7 @@ library(tidymodels)
 ```
 
 
-##  {background-image="images/tm-org.png" background-size="1000px"}
+##  {background-image="images/tm-org.png" background-size="contain"}
 
 ## The whole game
 

--- a/slides/02-data-budget.qmd
+++ b/slides/02-data-budget.qmd
@@ -17,7 +17,7 @@ knitr:
 #| file: setup.R
 ```
 
-##  {background-image="https://media.giphy.com/media/Lr3UeH9tYu3qJtsSUg/giphy.gif" background-size="600px"}
+##  {background-image="https://media.giphy.com/media/Lr3UeH9tYu3qJtsSUg/giphy.gif" background-size="40%"}
 
 ## Data on tree frog hatching
 
@@ -195,9 +195,9 @@ nrow(frog_test)
 
 # What about a validation set?
 
-##  {background-color="white" background-image="https://www.tmwr.org/premade/validation.svg" background-size="800px"}
+##  {background-color="white" background-image="https://www.tmwr.org/premade/validation.svg" background-size="50%"}
 
-##  {background-color="white" background-image="https://www.tmwr.org/premade/validation-alt.svg" background-size="800px"}
+##  {background-color="white" background-image="https://www.tmwr.org/premade/validation-alt.svg" background-size="50%"}
 
 # Exploratory data analysis for ML 🧐 
 

--- a/slides/03-what-makes-a-model.qmd
+++ b/slides/03-what-makes-a-model.qmd
@@ -249,7 +249,7 @@ ggplot(data = tree_preds, aes(age, latency)) +
 
 # A model workflow
 
-##  {background-image="https://media.giphy.com/media/xUA7b0Klw8Wfor7FWo/giphy.gif" background-size="800px"}
+##  {background-image="https://media.giphy.com/media/xUA7b0Klw8Wfor7FWo/giphy.gif" background-size="50%"}
 
 # Placeholder for workflow diagrams from TMwR
 

--- a/slides/04-evaluating-models.qmd
+++ b/slides/04-evaluating-models.qmd
@@ -162,7 +162,7 @@ Really though... don't use the test set until the *very* end of modeling.
 
 We're just demonstrating overfitting here.
 
-##  {background-image="https://media.giphy.com/media/55itGuoAJiZEEen9gg/giphy.gif" background-size="800px"}
+##  {background-image="https://media.giphy.com/media/55itGuoAJiZEEen9gg/giphy.gif" background-size="70%"}
 
 ## Your turn {transition="slide-in"}
 
@@ -213,7 +213,7 @@ And we want to understand if these are important differences?
 
 # How can we use the *training* data to compare and evaluate different models? 🤔
 
-##  {background-color="white" background-image="https://www.tmwr.org/premade/resampling.svg" background-size="1000px"}
+##  {background-color="white" background-image="https://www.tmwr.org/premade/resampling.svg" background-size="80%"}
 
 ## Cross-validation
 


### PR DESCRIPTION
I found that using unit based sizing yielded suboptimal sizes for small and large screen. This PR switches images that appear on a slide with a title, to use the `![](path)` syntax, and the other background images have had their size specified by percentages.

# Before - small screen
<img width="889" alt="Screen Shot 2022-06-03 at 5 07 47 PM" src="https://user-images.githubusercontent.com/14034784/171968704-cc2800f4-7181-4875-9692-9be8f4bdd611.png">

# Before - big screen
![Screen Shot 2022-06-03 at 5 07 53 PM](https://user-images.githubusercontent.com/14034784/171968716-5e2b92e2-8876-4304-9c96-775816c4d243.png)

# After - small screen
<img width="883" alt="Screen Shot 2022-06-03 at 5 07 22 PM" src="https://user-images.githubusercontent.com/14034784/171968737-28b8a248-66be-40ba-bde2-4b1a22ec034a.png">

# After - big screen
![Screen Shot 2022-06-03 at 5 07 30 PM](https://user-images.githubusercontent.com/14034784/171968743-4460b692-b721-477f-bd8c-141804300790.png)