### PR TITLE
Tweaks to discussion about parallelism

### DIFF
--- a/slides/04-evaluating-models.qmd
+++ b/slides/04-evaluating-models.qmd
@@ -333,7 +333,8 @@ Set the seed when creating resamples
 ## Evaluating model performance `r hexes("tune")`
 
 ```{r}
-fit_resamples(tree_wflow, frog_folds)
+tree_res <- fit_resamples(tree_wflow, frog_folds)
+tree_res
 ```
 
 . . .
@@ -343,7 +344,8 @@ Where are the fitted models??!??
 ## Evaluating model performance `r hexes("tune")`
 
 ```{r}
-fit_resamples(tree_wflow, frog_folds)
+tree_res <- fit_resamples(tree_wflow, frog_folds)
+tree_res
 ```
 
 Where are the fitted models??!??
@@ -356,31 +358,13 @@ For more advanced use cases, you can extract and save them: <https://www.tmwr.or
 ## Evaluating model performance `r hexes("tune")`
 
 ```{r}
-fit_resamples(tree_wflow, frog_folds) %>%
+tree_res %>%
   collect_metrics()
 ```
 
 . . .
 
 We can reliably measure performance using only the **training** data 🎉
-
-## Embarrassingly parallel `r hexes("tune")`
-
-```{r}
-doParallel::registerDoParallel()
-
-# Save the assessment set results
-ctrl_frog <- control_resamples(save_pred = TRUE)
-
-set.seed(1)
-tree_res <- fit_resamples(tree_wflow, frog_folds, control = ctrl_frog)
-
-tree_res %>% collect_metrics()
-```
-
-. . .
-
-Each fit is independent of the others
 
 ## Comparing metrics `r hexes("yardstick")`
 
@@ -431,12 +415,11 @@ Remember that:
 ## Evaluating model performance `r hexes("tune")`
 
 ```{r}
+# Save the assessment set results
 ctrl_frog <- control_resamples(save_pred = TRUE)
+tree_res <- fit_resamples(tree_wflow, frog_folds, control = ctrl_frog)
 
-tree_preds <- 
-  tree_res %>%
-  collect_predictions()
-
+tree_preds <- collect_predictions(tree_res)
 tree_preds
 ```
 

--- a/slides/06-tuning-hyperparameters.qmd
+++ b/slides/06-tuning-hyperparameters.qmd
@@ -25,11 +25,10 @@ knitr:
 #| include: false
 library(rpart)
 library(partykit)
-library(doParallel)
 
 cores <- parallel::detectCores(logical = FALSE)
-cl <- makePSOCKcluster(cores)
-registerDoParallel(cl)
+cl <- parallel::makePSOCKcluster(cores)
+doParallel::registerDoParallel(cl)
 
 options(width = 200)
 
@@ -474,16 +473,17 @@ countdown(minutes = 3, id = "xgb-wflow")
 
 -   These models don't depend on one another and can be run in parallel.
 
-::: fragment
 We can use a *parallel backend* to do this:
 
 ```{r, eval= FALSE}
 cores <- parallel::detectCores(logical = FALSE)
-library(doParallel)
-cl <- makePSOCKcluster(cores)
-registerDoParallel(cl)
+cl <- parallel::makePSOCKcluster(cores)
+doParallel::registerDoParallel(cl)
+
+# Shut it down with:
+foreach::registerDoSEQ()
+parallel::stopCluster(cl)
 ```
-:::
 :::
 
 ::: {.column width="40%"}
@@ -690,5 +690,6 @@ predict(final_xgb_wflow, nhl_test[1:3,])
 
 ```{r teardown}
 #| include: false
+foreach::registerDoSEQ()
 parallel::stopCluster(cl)
 ```


### PR DESCRIPTION
Closes #31 

@juliasilge could you please re-render both decks for me? As usual, it changes way too many things when I do it 😢 

- Removed talk about parallelism from deck 4. We do a much better job in deck 6 and it doesn't matter much in deck 4
- Updated deck 6 to also mention how to correctly shut down the cluster
  - There was also a bug (I guess in revealjs?) where if you have a `fragment` in a column then it won't show up at all, so I removed it. I think it looks fine.
- Updated deck 6 to more correctly shut down the foreach cluster in the teardown chunk

