### PR TITLE
Add preprocessor before model when describing workflows

### DIFF
--- a/slides/03-what-makes-a-model.qmd
+++ b/slides/03-what-makes-a-model.qmd
@@ -407,8 +407,8 @@ tree_spec <-
   set_mode("regression")
 
 workflow() %>%
-  add_model(tree_spec) %>%
   add_formula(latency ~ .) %>%
+  add_model(tree_spec) %>%
   fit(data = frog_train) 
 ```
 
@@ -420,8 +420,8 @@ tree_spec <-
   set_mode("regression")
 
 workflow() %>%
-  add_model(tree_spec) %>%
   add_variables(outcomes = latency, predictors = everything()) %>%
+  add_model(tree_spec) %>%
   fit(data = frog_train) 
 ```
 


### PR DESCRIPTION
Because preprocessor before model makes more sense when teaching, and later when we do `workflow(latency ~ ., spec)` the order will be consistent