### PR TITLE
Remove hexes when using an H1 header

### DIFF
--- a/slides/03-what-makes-a-model.qmd
+++ b/slides/03-what-makes-a-model.qmd
@@ -496,7 +496,7 @@ countdown(minutes = 3, id = "predict-tree-fit")
 countdown(minutes = 3, id = "augment-tree-fit")
 ```
 
-# The tidymodels prediction guarantee! `r hexes("parsnip", "workflows")`
+# The tidymodels prediction guarantee!
 
 . . .
 


### PR DESCRIPTION
They cover the slide title when we use an H1 header

<img width="1650" alt="Screen Shot 2022-07-12 at 11 17 20 AM" src="https://user-images.githubusercontent.com/19150088/178525454-1ce7ea4a-ffe8-4ca5-a79f-710ef3d5308a.png">
