### PR TITLE
Move bad-workflow image to right after good-workflow image

### DIFF
--- a/slides/03-what-makes-a-model.qmd
+++ b/slides/03-what-makes-a-model.qmd
@@ -340,6 +340,15 @@ ggplot(data = tree_preds, aes(age, latency)) +
 knitr::include_graphics("images/good_workflow.png")
 ```
 
+## What is wrong with this? {.annotation}
+
+```{r bad-workflow}
+#| echo: false
+#| out-width: '70%'
+#| fig-aling: 'center'
+knitr::include_graphics("images/bad_workflow.png")
+```
+
 ## Why a `workflow()`? `r hexes("workflows")`
 
 . . .
@@ -365,15 +374,6 @@ Two ways workflows handle levels better than `model.matrix()`:
 
 -   Restores missing levels that were present at fit time, but happen to be missing at prediction time (like, if your "new" data just doesn't have an instance of that level)
 :::
-
-## What is wrong with this? {.annotation}
-
-```{r bad-workflow}
-#| echo: false
-#| out-width: '70%'
-#| fig-aling: 'center'
-knitr::include_graphics("images/bad_workflow.png")
-```
 
 ## A model workflow `r hexes("parsnip", "workflows")`
 


### PR DESCRIPTION
Because it is natural to talk about these together, rather than talking about what a workflow is in between

@juliasilge does this make sense to you? I was practicing this and it is weird to talk about the modeling workflow capturing both preprocessing and model fitting without having this slide close to it