### PR TITLE
name classwork code chunks according to slides

### DIFF
--- a/classwork/03-classwork.qmd
+++ b/classwork/03-classwork.qmd
@@ -55,7 +55,7 @@ decision_tree() %>%
 
 Edit the chunk below to use a different model!
 
-```{r}
+```{r tree_spec}
 tree_spec <- decision_tree() %>% 
   set_mode("regression")
 
@@ -108,7 +108,7 @@ Edit this code so it:
 - creates a different model
 - uses one of the other `workflow()` interfaces
 
-```{r}
+```{r tree_wflow}
 tree_spec <-
   decision_tree() %>% 
   set_mode("regression")


### PR DESCRIPTION
The prompt in the slides includes "Run the `tree_spec chunk` in your `.qmd`." so this names those chucks to make them easier to identify