### PR TITLE
Update annotations

### DIFF
--- a/slides/annotations.qmd
+++ b/slides/annotations.qmd
@@ -131,22 +131,6 @@ As shown in the Whole Game slides, there is a slightly different scheme used whe
 
 # 05 - Feature Engineering
 
-## Splitting the NHL data 
-
-`nhl_train` isn't really the right name for these data. 
-
-In a little bit, we'll use the `validation_split()` function to take the rows in `nhl_train` and make a validation set. The data that are not used in the validation set are the data that we will use to build the models during tuning. 
-
-Recall the Whole Game slide had: 
-
-```{r spending-diagram, echo = FALSE}
-#| fig-align: "center"
-
-knitr::include_graphics("images/whole-game-split.svg")
-```
-
-`nhl_train` has the "Not Testing" data. 
-
 ## Per-player statistics
 
 The effect encoding method essentially takes the effect of a variable, like player, and makes a data column for that effect. In our example, the ability of a player to have an on-goal shot is quantified by a model and then added as a data column to be used in the model. 


### PR DESCRIPTION
This removes the comment on object name `nhl_train` since it got renamed to `nhl_train_and_val`.