### PR TITLE
One line fix: age days -> seconds in description

### DIFF
--- a/slides/02-data-budget.qmd
+++ b/slides/02-data-budget.qmd
@@ -69,7 +69,7 @@ tree_frogs <- tree_frogs %>%
 
 - t_o_d: Time that the stimulus was applied (morning, afternoon, night)
 
-- age: Age at the time it was stimulated (in seconds)
+- age: Age at the time it was stimulated (in days)
 :::
 
 ## Data on tree frog hatching


### PR DESCRIPTION
Since #88, the unit of the age column is days @juliasilge 