### PR TITLE
Use `parallelly::availableCores()` everywhere

### DIFF
--- a/classwork/06-classwork.qmd
+++ b/classwork/06-classwork.qmd
@@ -205,7 +205,7 @@ Create your boosted tree workflow.
 ## Running in parallel
 
 ```{r}
-cores <- parallel::detectCores(logical = FALSE)
+cores <- parallelly::availableCores(logical = FALSE)
 cl <- parallel::makePSOCKcluster(cores)
 doParallel::registerDoParallel(cl)
 ```

--- a/slides/05-feature-engineering.qmd
+++ b/slides/05-feature-engineering.qmd
@@ -32,7 +32,7 @@ library(emo)
 
 library(doParallel)
 
-cores <- parallel::detectCores(logical = FALSE)
+cores <- parallelly::availableCores(logical = FALSE)
 cl <- makePSOCKcluster(cores)
 registerDoParallel(cl)
 

--- a/slides/06-tuning-hyperparameters.qmd
+++ b/slides/06-tuning-hyperparameters.qmd
@@ -27,7 +27,7 @@ knitr:
 library(rpart)
 library(partykit)
 
-cores <- parallel::detectCores(logical = FALSE)
+cores <- parallelly::availableCores(logical = FALSE)
 cl <- parallel::makePSOCKcluster(cores)
 doParallel::registerDoParallel(cl)
 
@@ -586,7 +586,7 @@ countdown::countdown(minutes = 3, id = "xgb-wflow")
 We can use a *parallel backend* to do this:
 
 ```{r, eval= FALSE}
-cores <- parallel::detectCores(logical = FALSE)
+cores <- parallelly::availableCores(logical = FALSE)
 cl <- parallel::makePSOCKcluster(cores)
 doParallel::registerDoParallel(cl)
 


### PR DESCRIPTION
Because `parallel::detectCores()` won't respect your "allocated" amount of cores. In the 2022 tidymodels rstudio conf workshop, our rstudio cloud instances technically had 16 cores available to them, but users were only allocated 2 of them. `parallel::detectCores()` returned `16`, causing `makePSOCKcluster()` to hang indefinitely.

Thanks for parallelly @HenrikBengtsson 😄, this is the first time where this has ever actually been an issue for me. Switching to parallelly fixed it immediately 