### PR TITLE
Refer back to whole game in decks 2-4

### DIFF
--- a/slides/02-data-budget.qmd
+++ b/slides/02-data-budget.qmd
@@ -357,3 +357,11 @@ bind_rows(
   ggplot(aes(x = split, fill = tip)) +
   geom_bar(position = "fill")
 ```
+
+## The whole game - status update
+
+```{r diagram-split, echo = FALSE}
+#| fig-align: "center"
+
+knitr::include_graphics("images/whole-game-split.jpg")
+```

--- a/slides/03-what-makes-a-model.qmd
+++ b/slides/03-what-makes-a-model.qmd
@@ -680,3 +680,15 @@ Live-code making a prediction
 #| echo: false
 countdown(minutes = 5, id = "vetiver")
 ```
+
+## The whole game - status update
+
+```{r diagram-model-1, echo = FALSE}
+#| fig-align: "center"
+
+knitr::include_graphics("images/whole-game-model-1.jpg")
+```
+
+:::notes
+Stress that fitting a model on the entire training set was only for illustrating how to fit a model
+:::

--- a/slides/04-evaluating-models.qmd
+++ b/slides/04-evaluating-models.qmd
@@ -570,6 +570,14 @@ bootstraps(taxi_train)
 ::: footer
 :::
 
+## The whole game - status update
+
+```{r diagram-resamples, echo = FALSE}
+#| fig-align: "center"
+
+knitr::include_graphics("images/whole-game-resamples.jpg")
+```
+
 ## Your turn {transition="slide-in"}
 
 ![](images/parsnip-flagger.jpg){.absolute top="0" right="0" width="150" height="150"}
@@ -691,7 +699,6 @@ The first metric of the metric set is used for ranking. Use `rank_metric` to cha
 
 Lots more available with workflow sets, like `collect_metrics()`, `autoplot()` methods, and more!
 
-
 ## Your turn {transition="slide-in"}
 
 ![](images/parsnip-flagger.jpg){.absolute top="0" right="0" width="150" height="150"}
@@ -701,6 +708,14 @@ Lots more available with workflow sets, like `collect_metrics()`, `autoplot()` m
 ```{r}
 #| echo: false
 countdown(minutes = 3, id = "discuss-workflow-sets")
+```
+
+## The whole game - status update
+
+```{r diagram-select, echo = FALSE}
+#| fig-align: "center"
+
+knitr::include_graphics("images/whole-game-select.jpg")
 ```
 
 ## The final fit `r hexes("tune")` 
@@ -745,6 +760,14 @@ extract_workflow(final_fit)
 . . .
 
 Use this for **prediction** on new data, like for deploying
+
+## The whole game
+
+```{r diagram-final-performance, echo = FALSE}
+#| fig-align: "center"
+
+knitr::include_graphics("images/whole-game-final-performance.jpg")
+```
 
 ## Your turn {transition="slide-in"}
 


### PR DESCRIPTION
This PR include references to different stages in the diagram series for the whole game:

- To just the split in train/test at the end of deck 2
- To fitting a decison tree on the training set at the end of deck 3 - with notes to make clear that this was to illustrate the syntax for fitting and we won't actually fit on the entire training set in the whole game
- To resamples after showing the pkgdown site for rsample, before the last exercise on resamples
- To selecting a model before we go into the Final Fit section (which is after the workflow set)
- To the full whole game diagram at the end of deck 4, just before the last slide with end of day discussion