### PR TITLE
2023 NYR Deck 4: tweak taxi image

### DIFF
--- a/slides/04-evaluating-models.qmd
+++ b/slides/04-evaluating-models.qmd
@@ -662,7 +662,14 @@ rf_res <- fit_resamples(rf_wflow, taxi_folds, control = ctrl_taxi)
 collect_metrics(rf_res)
 ```
 
-## How can we compare multiple model workflows at once? {background-image="images/taxi_spinning.svg"}
+## How can we compare multiple model workflows at once?
+
+```{r taxi-spinning, echo = FALSE}
+#| fig-align: "center"
+
+knitr::include_graphics("images/taxi_spinning.svg")
+```
+
 
 ## Evaluate a workflow set
 


### PR DESCRIPTION
Using it as a background image meant that the header text overlapped with the taxi so now it's the "main slide content".