### PR TITLE
set `eval = FALSE` for `plumber::pr_run()`

### DIFF
--- a/classwork/03-classwork.qmd
+++ b/classwork/03-classwork.qmd
@@ -184,6 +184,7 @@ pr
 ```
 
 ```{r}
+#| eval: false
 # Run the API server in a new window
 pr_run(pr)
 ```


### PR DESCRIPTION
Closes #191.

This was only an issue for the classwork files because the slides don't include that code. plumber pulls up the rapidocs and then hangs when rendering.