### PR TITLE
fix syntax highlighting

### DIFF
--- a/slides/advanced-03-racing.qmd
+++ b/slides/advanced-03-racing.qmd
@@ -303,7 +303,7 @@ The [finetune](https://finetune.tidymodels.org/) package has functions `tune_rac
 ```{r } 
 #| label: lgb-grid-race
 #| cache: false
-#| code-line-numbers: "1-8|"
+#| code-line-numbers: "12|"
 # Let's use a larger grid
 set.seed(8945)
 lgbm_grid <- 

--- a/slides/advanced-03-racing.qmd
+++ b/slides/advanced-03-racing.qmd
@@ -303,7 +303,7 @@ The [finetune](https://finetune.tidymodels.org/) package has functions `tune_rac
 ```{r } 
 #| label: lgb-grid-race
 #| cache: false
-#| code-line-numbers: "1,8|"
+#| code-line-numbers: "1-8|"
 # Let's use a larger grid
 set.seed(8945)
 lgbm_grid <- 


### PR DESCRIPTION
Closes #181.

I thiiink this was the intent of those lines? Initially only highlight lines 1 _through_ 8, rather than 1 _and_ 8, which correspond to the code that makes the grid.