### PR TITLE
transition from rpart.plot to partykit

### DIFF
--- a/classwork/03-classwork.qmd
+++ b/classwork/03-classwork.qmd
@@ -139,11 +139,12 @@ augment(tree_fit, new_data = taxi_test)
 ## Understand your model
 
 ```{r}
-library(rpart.plot)
+library(partykit)
 
 tree_fit %>%
   extract_fit_engine() %>%
-  rpart.plot(roundint = FALSE)
+  as.party.rpart() %>%
+  plot()
 ```
 
 ## Your turn

--- a/index.qmd
+++ b/index.qmd
@@ -36,8 +36,8 @@ install.packages("pak")
 
 # Then the packages for both days
 pkgs <- 
-  c("bonsai", "doParallel", "finetune", "lightgbm", "lme4", "plumber", 
-    "probably", "ranger", "rpart", "rpart.plot", "stacks", "textrecipes", 
+  c("bonsai", "doParallel", "finetune", "lightgbm", "lme4", "partykit",
+    "plumber", "probably", "ranger", "rpart", "stacks", "textrecipes", 
     "tidymodels", "tidymodels/modeldatatoo", "vetiver")
 pak::pak(pkgs)
 ```

--- a/slides/01-introduction.qmd
+++ b/slides/01-introduction.qmd
@@ -229,7 +229,7 @@ If you are using your own laptop instead of RStudio Cloud:
 install.packages("pak")
 
 pkgs <- c("bonsai", "doParallel", "embed", "finetune", "lightgbm", "lme4", 
-          "parallelly", "plumber", "probably", "ranger", "rpart", "rpart.plot", 
+          "parallelly", "partykit", "plumber", "probably", "ranger", "rpart", 
           "stacks", "textrecipes", "tidymodels", "tidymodels/modeldatatoo", 
           "vetiver")
 pak::pak(pkgs)
@@ -244,7 +244,7 @@ Check Slack (`#ml-ws-2023`) for an RStudio Cloud link.
 
 ```{r pkg-list, echo = FALSE}
 deps <- c("bonsai", "doParallel", "embed", "finetune", "lightgbm", "lme4", 
-          "parallelly", "plumber", "probably", "ranger", "rpart", "rpart.plot", 
+          "parallelly", "partykit", "plumber", "probably", "ranger", "rpart",
           "stacks", "textrecipes", "tidymodels", "modeldatatoo", 
           "vetiver")
 loaded <- purrr::map(deps, ~ library(.x, character.only = TRUE))

--- a/slides/03-what-makes-a-model.qmd
+++ b/slides/03-what-makes-a-model.qmd
@@ -305,10 +305,11 @@ tree_preds <-
 ```{r}
 #| echo: false
 #| fig-align: center
-library(rpart.plot)
+library(partykit)
 tree_fit %>%
   extract_fit_engine() %>%
-  rpart.plot(roundint = FALSE)
+  as.party.rpart() %>%
+  plot()
 ```
 
 :::
@@ -324,10 +325,10 @@ tree_fit %>%
 ```{r}
 #| echo: false
 #| fig-align: center
-library(rpart.plot)
 tree_fit %>%
   extract_fit_engine() %>%
-  rpart.plot(roundint = FALSE)
+  as.party.rpart() %>%
+  plot()
 ```
 :::
 
@@ -349,10 +350,10 @@ tree_fit %>%
 #| fig.width: 8
 #| fig.height: 7
 #| fig-align: center
-library(rpart.plot)
 tree_fit %>%
   extract_fit_engine() %>%
-  rpart.plot(roundint = FALSE)
+  as.party.rpart() %>%
+  plot()
 ```
 :::
 
@@ -569,10 +570,10 @@ How do you **understand** your new `tree_fit` model?
 ```{r}
 #| echo: false
 #| fig-align: center
-library(rpart.plot)
 tree_fit %>%
   extract_fit_engine() %>%
-  rpart.plot(roundint = FALSE)
+  as.party.rpart() %>%
+  plot()
 ```
 
 ## Understand your model `r hexes("parsnip", "workflows")`
@@ -581,10 +582,10 @@ How do you **understand** your new `tree_fit` model?
 
 ```{r}
 #| eval: false
-library(rpart.plot)
 tree_fit %>%
   extract_fit_engine() %>%
-  rpart.plot(roundint = FALSE)
+  as.party.rpart() %>%
+  plot()
 ```
 
 You can `extract_*()` several components of your fitted workflow.


### PR DESCRIPTION
Closes #163. They do look good!

This also removes the redundant `library()` calls in "What makes a model" to make space for that additional `as.party.rpart()` line.