### PR TITLE
make size of decision tree plots consistent

### DIFF
--- a/slides/03-what-makes-a-model.qmd
+++ b/slides/03-what-makes-a-model.qmd
@@ -304,6 +304,8 @@ tree_preds <-
 
 ```{r}
 #| echo: false
+#| fig.width: 8
+#| fig.height: 7
 #| fig-align: center
 library(rpart.plot)
 tree_fit %>%
@@ -323,6 +325,8 @@ tree_fit %>%
 ::: {.column width="50%"}
 ```{r}
 #| echo: false
+#| fig.width: 8
+#| fig.height: 7
 #| fig-align: center
 library(rpart.plot)
 tree_fit %>%


### PR DESCRIPTION
Closes #157. These figure options had been set in other chunks for the same plot, so I just additionally set them here to make the plots the same size when they were previously smaller.

This will be aided by #208, too. :)