### PR TITLE
use versioned taxi data in archive

### DIFF
--- a/archive/2023-07-nyr/02-data-budget.qmd
+++ b/archive/2023-07-nyr/02-data-budget.qmd
@@ -32,7 +32,7 @@ knitr:
 ::: {.column width="60%"}
 -   The city of Chicago releases anonymized trip-level data on taxi trips in the city.
 -   We pulled a sample of 10,000 rides occurring in early 2022.
--   Type `?modeldatatoo::data_taxi()` to learn more about this dataset, including references.
+-   Type `?modeldatatoo::data_taxi(version = "20230630T214846Z-643d0")` to learn more about this dataset, including references.
 :::
 
 ::: {.column width="40%"}
@@ -51,7 +51,7 @@ Credit: <https://www.svgrepo.com/svg/8322/taxi>
 library(tidymodels)
 library(modeldatatoo)
 
-taxi <- data_taxi()
+taxi <- data_taxi(version = "20230630T214846Z-643d0")
 
 names(taxi)
 ```

--- a/archive/2023-07-nyr/03-what-makes-a-model.qmd
+++ b/archive/2023-07-nyr/03-what-makes-a-model.qmd
@@ -73,7 +73,7 @@ countdown(minutes = 3, id = "how-to-fit-linear-model")
 library(tidymodels)
 library(modeldatatoo)
 
-taxi <- data_taxi()
+taxi <- data_taxi(version = "20230630T214846Z-643d0")
 
 taxi <- taxi %>%
   mutate(month = factor(month, levels = c("Jan", "Feb", "Mar", "Apr"))) %>% 

--- a/archive/2023-07-nyr/04-evaluating-models.qmd
+++ b/archive/2023-07-nyr/04-evaluating-models.qmd
@@ -30,7 +30,7 @@ knitr:
 library(countdown)
 library(tidymodels)
 library(modeldatatoo)
-taxi <- data_taxi() %>%
+taxi <- data_taxi(version = "20230630T214846Z-643d0") %>%
   mutate(month = factor(month, levels = c("Jan", "Feb", "Mar", "Apr"))) %>% 
   select(-c(id, duration, fare, tolls, extras, total_cost, payment_type)) %>%
   drop_na()

--- a/archive/2023-07-nyr/classwork/02-classwork.qmd
+++ b/archive/2023-07-nyr/classwork/02-classwork.qmd
@@ -13,7 +13,7 @@ We recommend restarting R between each slide deck!
 library(tidymodels)
 library(modeldatatoo)
 
-taxi <- data_taxi()
+taxi <- data_taxi(version = "20230630T214846Z-643d0")
 
 # Slightly modify the original data for the purposes of this workshop
 taxi <- taxi %>%

--- a/archive/2023-07-nyr/classwork/03-classwork.qmd
+++ b/archive/2023-07-nyr/classwork/03-classwork.qmd
@@ -15,7 +15,7 @@ Setup from deck 2
 library(tidymodels)
 library(modeldatatoo)
 
-taxi <- data_taxi()
+taxi <- data_taxi(version = "20230630T214846Z-643d0")
 
 taxi <- taxi %>%
   mutate(month = factor(month, levels = c("Jan", "Feb", "Mar", "Apr"))) %>% 

--- a/archive/2023-07-nyr/classwork/04-classwork.qmd
+++ b/archive/2023-07-nyr/classwork/04-classwork.qmd
@@ -15,7 +15,7 @@ Setup from deck 3
 library(tidymodels)
 library(modeldatatoo)
 
-taxi <- data_taxi()
+taxi <- data_taxi(version = "20230630T214846Z-643d0")
 
 taxi <- taxi %>%
   mutate(month = factor(month, levels = c("Jan", "Feb", "Mar", "Apr"))) %>% 


### PR DESCRIPTION
We moved some of the data preprocessing into `modeldatatoo::data_taxi()` as seen here https://github.com/tidymodels/modeldatatoo/pull/28.

For backwards compatibility, This PR uses the old version of the data in the NYR material

Ref https://github.com/tidymodels/workshops/issues/150