### PR TITLE
use modeldata instead of modeldatatoo

### DIFF
--- a/classwork/advanced-01-classwork.qmd
+++ b/classwork/advanced-01-classwork.qmd
@@ -11,7 +11,6 @@ We recommend restarting R between each slide deck!
 
 ```{r}
 library(tidymodels)
-library(modeldatatoo)
 
 # Max's usual settings: 
 tidymodels_prefer()
@@ -23,7 +22,7 @@ options(
 
 set.seed(295)
 hotel_rates <- 
-  data_hotel_rates() %>% 
+  hotel_rates %>% 
   sample_n(5000) %>% 
   arrange(arrival_date) %>% 
   select(-arrival_date_num, -arrival_date) %>% 

--- a/classwork/advanced-02-classwork.qmd
+++ b/classwork/advanced-02-classwork.qmd
@@ -13,7 +13,6 @@ Setup from deck 1
 
 ```{r}
 library(tidymodels)
-library(modeldatatoo)
 library(textrecipes)
 
 # Max's usual settings: 
@@ -28,7 +27,7 @@ reg_metrics <- metric_set(mae, rsq)
 
 set.seed(295)
 hotel_rates <- 
-  data_hotel_rates() %>% 
+  hotel_rates %>% 
   sample_n(5000) %>% 
   arrange(arrival_date) %>% 
   select(-arrival_date_num, -arrival_date) %>% 

--- a/classwork/advanced-03-classwork.qmd
+++ b/classwork/advanced-03-classwork.qmd
@@ -13,7 +13,6 @@ Setup from deck 2
 
 ```{r}
 library(tidymodels)
-library(modeldatatoo)
 library(textrecipes)
 library(bonsai)
 
@@ -29,7 +28,7 @@ reg_metrics <- metric_set(mae, rsq)
 
 set.seed(295)
 hotel_rates <- 
-  data_hotel_rates() %>% 
+  hotel_rates %>% 
   sample_n(5000) %>% 
   arrange(arrival_date) %>% 
   select(-arrival_date_num, -arrival_date) %>% 

--- a/classwork/advanced-04-classwork.qmd
+++ b/classwork/advanced-04-classwork.qmd
@@ -13,7 +13,6 @@ Setup from deck 3
 
 ```{r}
 library(tidymodels)
-library(modeldatatoo)
 library(textrecipes)
 library(bonsai)
 library(probably)
@@ -28,7 +27,7 @@ options(
 
 set.seed(295)
 hotel_rates <- 
-  data_hotel_rates() %>% 
+  hotel_rates %>% 
   sample_n(5000) %>% 
   arrange(arrival_date) %>% 
   select(-arrival_date_num, -arrival_date) %>% 

--- a/classwork/intro-02-classwork.qmd
+++ b/classwork/intro-02-classwork.qmd
@@ -11,12 +11,7 @@ We recommend restarting R between each slide deck!
 
 ```{r}
 library(tidymodels)
-library(modeldatatoo)
 
-taxi <- data_taxi()
-```
-
-```{r}
 taxi
 ```
 

--- a/classwork/intro-03-classwork.qmd
+++ b/classwork/intro-03-classwork.qmd
@@ -13,12 +13,8 @@ Setup from deck 2
 
 ```{r}
 library(tidymodels)
-library(modeldatatoo)
-
-taxi <- data_taxi()
 
 set.seed(123)
-
 taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
 taxi_train <- training(taxi_split)
 taxi_test <- testing(taxi_split)

--- a/classwork/intro-04-classwork.qmd
+++ b/classwork/intro-04-classwork.qmd
@@ -13,9 +13,6 @@ Setup from deck 3
 
 ```{r}
 library(tidymodels)
-library(modeldatatoo)
-
-taxi <- data_taxi()
 
 set.seed(123)
 taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)

--- a/classwork/intro-extra-recipes-classwork.qmd
+++ b/classwork/intro-extra-recipes-classwork.qmd
@@ -13,9 +13,6 @@ Setup from deck 3
 
 ```{r}
 library(tidymodels)
-library(modeldatatoo)
-
-taxi <- data_taxi()
 
 set.seed(123)
 taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)

--- a/index.qmd
+++ b/index.qmd
@@ -56,23 +56,6 @@ pkgs <-
 install.packages(pkgs)
 ```
 
-It is also recommended that you run the following code. This ensures that the needed data is cached on your computer.
-
-```{r}
-library(modeldatatoo)
-
-# Introduction to tidymodels
-data_taxi()
-
-# Advanced tidymodels
-data_hotel_rates()
-```
-
-If that doesn't work with your setup/configurations, you can manually download the data sets with the following links, and read in the data with `readr::read_rds()` instead of calling the functions above.
-
-- [taxi](http://modeldatatoo.tidymodels.org/dev/pins-board/taxi/20230725T192705Z-b557d/)
-- [hotel_rates](http://modeldatatoo.tidymodels.org/dev/pins-board/hotel_rates/20230627T201835Z-e8f9a/hotel_rates.rds)
-
 If you encounter issues with any of these installations, feel free to [file an issue](https://github.com/tidymodels/workshops/issues/new/choose) on our workshop repository and we'll try to help you out.
 
 ## Slides

--- a/index.qmd
+++ b/index.qmd
@@ -54,8 +54,6 @@ pkgs <-
     "stacks", "textrecipes", "tidymodels", "vetiver", "remotes")
 
 install.packages(pkgs)
-
-remotes::install_github("tidymodels/modeldatatoo")
 ```
 
 It is also recommended that you run the following code. This ensures that the needed data is cached on your computer.

--- a/slides/advanced-01-feature-engineering.qmd
+++ b/slides/advanced-01-feature-engineering.qmd
@@ -92,8 +92,6 @@ pkgs <-
     "stacks", "textrecipes", "tidymodels", "vetiver", "remotes")
 
 install.packages(pkgs)
-
-remotes::install_github("tidymodels/modeldatatoo")
 ```
 
 ```{r}
@@ -102,7 +100,7 @@ remotes::install_github("tidymodels/modeldatatoo")
 
 # remotes::install_github("gadenbuie/countdown")
 # remotes::install_github("hadley/emo")
-library(modeldatatoo)
+library(modeldata)
 library(probably)
 library(countdown)
 library(emo)
@@ -197,7 +195,7 @@ These terms are often used interchangeably in the ML community but we want to di
 
 We'll use [data on hotels](https://www.sciencedirect.com/science/article/pii/S2352340918315191) to predict the cost of a room. 
 
-The [data](https://modeldatatoo.tidymodels.org/dev/reference/data_hotel_rates.html) are in the modeldatatoo package. We'll sample down the data and refactor some columns: 
+The [data](https://modeldata.tidymodels.org/reference/hotel_rates.html are in the modeldata package. We'll sample down the data and refactor some columns: 
 
 :::: {.columns}
 
@@ -206,7 +204,6 @@ The [data](https://modeldatatoo.tidymodels.org/dev/reference/data_hotel_rates.ht
 ```{r}
 #| label: tune-startup
 library(tidymodels)
-library(modeldatatoo)
 
 # Max's usual settings: 
 tidymodels_prefer()
@@ -225,7 +222,7 @@ options(
 #| label: data-import
 set.seed(295)
 hotel_rates <- 
-  data_hotel_rates() %>% 
+  hotel_rates %>% 
   sample_n(5000) %>% 
   arrange(arrival_date) %>% 
   select(-arrival_date_num, -arrival_date) %>% 

--- a/slides/advanced-02-tuning-hyperparameters.qmd
+++ b/slides/advanced-02-tuning-hyperparameters.qmd
@@ -25,7 +25,6 @@ knitr:
 
 ```{r more-setup}
 #| include: false
-library(modeldatatoo)
 library(probably)
 library(countdown)
 
@@ -48,7 +47,6 @@ ggplot2::theme_set(ggplot2::theme_bw())
 ```{r}
 #| label: tune-startup
 library(tidymodels)
-library(modeldatatoo)
 library(textrecipes)
 library(bonsai)
 
@@ -71,7 +69,7 @@ reg_metrics <- metric_set(mae, rsq)
 #| label: data-import
 set.seed(295)
 hotel_rates <- 
-  data_hotel_rates() %>% 
+  hotel_rates %>% 
   sample_n(5000) %>% 
   arrange(arrival_date) %>% 
   select(-arrival_date_num, -arrival_date) %>% 

--- a/slides/advanced-03-racing.qmd
+++ b/slides/advanced-03-racing.qmd
@@ -25,7 +25,6 @@ knitr:
 
 ```{r more-setup}
 #| include: false
-library(modeldatatoo)
 library(probably)
 library(countdown)
 library(finetune)
@@ -48,7 +47,6 @@ ggplot2::theme_set(ggplot2::theme_bw())
 ```{r}
 #| label: tune-startup
 library(tidymodels)
-library(modeldatatoo)
 library(textrecipes)
 library(bonsai)
 
@@ -71,7 +69,7 @@ reg_metrics <- metric_set(mae, rsq)
 #| label: data-import
 set.seed(295)
 hotel_rates <- 
-  data_hotel_rates() %>% 
+  hotel_rates %>% 
   sample_n(5000) %>% 
   arrange(arrival_date) %>% 
   select(-arrival_date_num, -arrival_date) %>% 

--- a/slides/advanced-04-iterative.qmd
+++ b/slides/advanced-04-iterative.qmd
@@ -25,7 +25,6 @@ knitr:
 
 ```{r more-setup}
 #| include: false
-library(modeldatatoo)
 library(probably)
 library(textrecipes)
 library(countdown)
@@ -51,7 +50,6 @@ load("bayes_opt_calcs.RData")
 ```{r}
 #| label: tune-startup
 library(tidymodels)
-library(modeldatatoo)
 library(textrecipes)
 library(bonsai)
 
@@ -72,7 +70,7 @@ options(
 #| label: data-import
 set.seed(295)
 hotel_rates <- 
-  data_hotel_rates() %>% 
+  hotel_rates %>% 
   sample_n(5000) %>% 
   arrange(arrival_date) %>% 
   select(-arrival_date_num, -arrival_date) %>% 

--- a/slides/extras-effect-encodings.qmd
+++ b/slides/extras-effect-encodings.qmd
@@ -26,7 +26,6 @@ knitr:
 
 ```{r more-setup}
 #| include: false
-library(modeldatatoo)
 library(probably)
 library(countdown)
 library(finetune)
@@ -49,7 +48,6 @@ ggplot2::theme_set(ggplot2::theme_bw())
 ```{r}
 #| label: tune-startup
 library(tidymodels)
-library(modeldatatoo)
 library(textrecipes)
 library(bonsai)
 
@@ -70,7 +68,7 @@ options(
 #| label: data-import
 set.seed(295)
 hotel_rates <- 
-  data_hotel_rates() %>% 
+  hotel_rates %>% 
   sample_n(5000) %>% 
   arrange(arrival_date) %>% 
   select(-arrival_date_num, -arrival_date) %>% 

--- a/slides/intro-01-introduction.qmd
+++ b/slides/intro-01-introduction.qmd
@@ -227,8 +227,6 @@ pkgs <-
     "stacks", "textrecipes", "tidymodels", "vetiver", "remotes")
 
 install.packages(pkgs)
-
-remotes::install_github("tidymodels/modeldatatoo")
 ```
 
 . . .

--- a/slides/intro-02-data-budget.qmd
+++ b/slides/intro-02-data-budget.qmd
@@ -140,7 +140,7 @@ one_split <- slice(taxi, 1:30) %>%
 all_split <-
   ggplot(one_split, aes(x = Row, y = fct_rev(Data), fill = Data)) + 
   geom_tile(color = "white",
-            size = 1) + 
+            linewidth = 1) + 
   scale_fill_manual(values = splits_pal, guide = "none") +
   theme_minimal() +
   theme(axis.text.y = element_text(size = rel(2)),

--- a/slides/intro-02-data-budget.qmd
+++ b/slides/intro-02-data-budget.qmd
@@ -32,7 +32,7 @@ knitr:
 ::: {.column width="60%"}
 -   The city of Chicago releases anonymized trip-level data on taxi trips in the city.
 -   We pulled a sample of 10,000 rides occurring in early 2022.
--   Type `?modeldatatoo::data_taxi()` to learn more about this dataset, including references.
+-   Type `?taxi` to learn more about this dataset, including references.
 :::
 
 ::: {.column width="40%"}
@@ -49,9 +49,6 @@ Credit: <https://www.svgrepo.com/svg/8322/taxi>
 
 ```{r load}
 library(tidymodels)
-library(modeldatatoo)
-
-taxi <- data_taxi()
 
 names(taxi)
 ```

--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -71,9 +71,6 @@ countdown(minutes = 3, id = "how-to-fit-linear-model")
 ```{r setup-previous}
 #| echo: false
 library(tidymodels)
-library(modeldatatoo)
-
-taxi <- data_taxi()
 
 set.seed(123)
 

--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -238,7 +238,7 @@ logistic_preds <-
 logistic_preds %>% 
   ggplot() +
   geom_histogram(aes(distance, fill = tip), position = "fill") +
-  geom_line(aes(x = distance, y = .pred_yes), size = 2, alpha = 0.8, color = data_color) +
+  geom_line(aes(x = distance, y = .pred_yes), linewidth = 2, alpha = 0.8, color = data_color) +
   labs(y = "") +
   theme_bw(base_size = 18)
 ```
@@ -259,7 +259,7 @@ logistic_preds %>%
 logistic_preds %>% 
   ggplot() +
   geom_histogram(aes(distance, fill = tip), position = "fill") +
-  geom_line(aes(x = distance, y = .pred_yes), size = 2, alpha = 0.8, color = data_color) +
+  geom_line(aes(x = distance, y = .pred_yes), linewidth = 2, alpha = 0.8, color = data_color) +
   labs(y = "") +
   theme_bw(base_size = 18)
 ```
@@ -361,7 +361,7 @@ tree_fit %>%
 tree_preds %>% 
   ggplot() +
   geom_histogram(aes(distance, fill = tip), position = "fill") +
-  geom_line(aes(x = distance, y = .pred_yes), size = 2, alpha = 0.8, color = data_color) +
+  geom_line(aes(x = distance, y = .pred_yes), linewidth = 2, alpha = 0.8, color = data_color) +
   labs(y = "") +
   theme_bw(base_size = 18)
 ```
@@ -381,7 +381,7 @@ tree_preds %>%
 logistic_preds %>% 
   ggplot() +
   geom_histogram(aes(distance, fill = tip), position = "fill") +
-  geom_line(aes(x = distance, y = .pred_yes), size = 2, alpha = 0.8, color = data_color) +
+  geom_line(aes(x = distance, y = .pred_yes), linewidth = 2, alpha = 0.8, color = data_color) +
   labs(y = "") +
   theme_bw(base_size = 18)
 ```
@@ -397,7 +397,7 @@ logistic_preds %>%
 tree_preds %>% 
   ggplot() +
   geom_histogram(aes(distance, fill = tip), position = "fill") +
-  geom_line(aes(x = distance, y = .pred_yes), size = 2, alpha = 0.8, color = data_color) +
+  geom_line(aes(x = distance, y = .pred_yes), linewidth = 2, alpha = 0.8, color = data_color) +
   labs(y = "") +
   theme_bw(base_size = 18)
 ```

--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -29,8 +29,6 @@ knitr:
 #| echo: false
 library(countdown)
 library(tidymodels)
-library(modeldatatoo)
-taxi <- data_taxi()
 
 set.seed(123)
 taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)

--- a/slides/intro-extra-recipes.qmd
+++ b/slides/intro-extra-recipes.qmd
@@ -31,8 +31,6 @@ knitr:
 #| echo: false
 library(countdown)
 library(tidymodels)
-library(modeldatatoo)
-taxi <- data_taxi()
 
 set.seed(123)
 taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)

--- a/slides/intro-extra-time-splits.qmd
+++ b/slides/intro-extra-time-splits.qmd
@@ -29,7 +29,6 @@ knitr:
 #| echo: false
 library(countdown)
 library(tidymodels)
-library(modeldatatoo)
 
 taxi_raw <- readr::read_rds("taxi_raw.rds")
 ```

--- a/slides/intro-extra-tune.qmd
+++ b/slides/intro-extra-tune.qmd
@@ -27,9 +27,7 @@ knitr:
 ```{r setup-previous}
 #| echo: false
 library(tidymodels)
-library(modeldatatoo)
 
-taxi <- data_taxi()
 
 set.seed(123)
 taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)

--- a/slides/intro-extra-workflowsets.qmd
+++ b/slides/intro-extra-workflowsets.qmd
@@ -28,8 +28,6 @@ knitr:
 #| echo: false
 library(countdown)
 library(tidymodels)
-library(modeldatatoo)
-taxi <- data_taxi()
 
 set.seed(123)
 taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)


### PR DESCRIPTION
With the new version of modeldata, we don't need the other package. 

Also, converted some `size` arguments to `linewidth` to avoid warnings