### PR TITLE
update our versions slide

### DIFF
--- a/slides/advanced-01-introduction.qmd
+++ b/slides/advanced-01-introduction.qmd
@@ -224,16 +224,47 @@ pkgs <-
   select(-date)
 df <- tibble::tibble(
   package = pkgs$package,
-  version = pkgs$ondiskversion,
-  source = ifelse(grepl("CRAN", pkgs$source), "CRAN", pkgs$source)
-) %>% 
-  mutate(
-    source = gsub(" (R 4.2.0)", "", source, fixed = TRUE),
-    source = substr(source, 1, 31),
-    info = paste0(package, " (", version, ", ", source, ")")
-  )
+  version = pkgs$ondiskversion
+)
+
+ids <- split(
+  seq_len(nrow(df)), 
+  ceiling(seq_len(nrow(df)) / ceiling(nrow(df) / 3))
+)
+
+column1 <- df %>%
+  dplyr::slice(ids[[1]])
+
+column2 <- df %>%
+  dplyr::slice(ids[[2]])
+
+column3 <- df %>%
+  dplyr::slice(ids[[3]])
+
 quarto_info <- paste0("Quarto (", system("quarto --version", intern = TRUE), ")")
-version_info <- knitr::combine_words(c(df$info, quarto_info))
 ```
 
-`r version_info`
+`r R.version.string`, `r quarto_info`
+
+::: {.columns style="font-size:0.7em;"}
+::: {.column width="33%"}
+```{r}
+#| echo: false
+knitr::kable(column1)
+```
+:::
+
+::: {.column width="33%"}
+```{r}
+#| echo: false
+knitr::kable(column2)
+```
+:::
+
+::: {.column width="33%"}
+```{r}
+#| echo: false
+knitr::kable(column3)
+```
+:::
+:::

--- a/slides/intro-01-introduction.qmd
+++ b/slides/intro-01-introduction.qmd
@@ -258,16 +258,47 @@ pkgs <-
   select(-date)
 df <- tibble::tibble(
   package = pkgs$package,
-  version = pkgs$ondiskversion,
-  source = ifelse(grepl("CRAN", pkgs$source), "CRAN", pkgs$source)
-) %>% 
-  mutate(
-    source = gsub(" (R 4.2.0)", "", source, fixed = TRUE),
-    source = substr(source, 1, 31),
-    info = paste0(package, " (", version, ", ", source, ")")
-  )
+  version = pkgs$ondiskversion
+)
+
+ids <- split(
+  seq_len(nrow(df)), 
+  ceiling(seq_len(nrow(df)) / ceiling(nrow(df) / 3))
+)
+
+column1 <- df %>%
+  dplyr::slice(ids[[1]])
+
+column2 <- df %>%
+  dplyr::slice(ids[[2]])
+
+column3 <- df %>%
+  dplyr::slice(ids[[3]])
+
 quarto_info <- paste0("Quarto (", system("quarto --version", intern = TRUE), ")")
-version_info <- knitr::combine_words(c(df$info, quarto_info))
 ```
 
-`r version_info`
+`r R.version.string`, `r quarto_info`
+
+::: {.columns style="font-size:0.7em;"}
+::: {.column width="33%"}
+```{r}
+#| echo: false
+knitr::kable(column1)
+```
+:::
+
+::: {.column width="33%"}
+```{r}
+#| echo: false
+knitr::kable(column2)
+```
+:::
+
+::: {.column width="33%"}
+```{r}
+#| echo: false
+knitr::kable(column3)
+```
+:::
+:::


### PR DESCRIPTION
I don't show CRAN labels as all the packages should be CRAN packages this time

What it looks like currently:

![Screenshot 2023-09-01 at 11 55 56 AM](https://github.com/tidymodels/workshops/assets/14034784/ee0d12e7-3847-426c-86b0-a007b13c24c9)

What this PR makes it look like

<img width="1534" alt="Screenshot 2023-09-01 at 11 35 31 AM" src="https://github.com/tidymodels/workshops/assets/14034784/9b5f4591-4c9d-4c46-9fec-18fb5a877717">
