### PR TITLE
Remove Quarto version from classwork section

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -92,7 +92,7 @@ There's also a page for [slide annotations](slides/annotations.html){target="_bl
 
 ## Code
 
-Quarto files (version `r system("quarto --version", intern = TRUE)`) for working along [are available on GitHub](https://github.com/tidymodels/workshops/tree/main/classwork). (Don't worry if you haven't used Quarto before; it will feel familiar to R Markdown users.)
+Quarto files for working along [are available on GitHub](https://github.com/tidymodels/workshops/tree/main/classwork). (Don't worry if you haven't used Quarto before; it will feel familiar to R Markdown users.)
 
 ## Past workshops
 


### PR DESCRIPTION
Having the version there makes it look like that's required to work with the classwork files. Especially with the add-on of "Don’t worry if you haven’t used Quarto before; it will feel familiar to R Markdown users." we don't want to make it look more complicated than it is.