### PR TITLE
fix numbering in advanced classwork

### DIFF
--- a/classwork/advanced-02-classwork.qmd
+++ b/classwork/advanced-02-classwork.qmd
@@ -1,5 +1,5 @@
 ---
-title: "1 - Feature Engineering - Classwork"
+title: "2 - Feature Engineering - Classwork"
 subtitle: "Advanced tidymodels"
 editor_options: 
   chunk_output_type: console

--- a/classwork/advanced-03-classwork.qmd
+++ b/classwork/advanced-03-classwork.qmd
@@ -1,5 +1,5 @@
 ---
-title: "2 - Tuning Hyperparameters - Classwork"
+title: "3 - Tuning Hyperparameters - Classwork"
 subtitle: "Advanced tidymodels"
 editor_options: 
   chunk_output_type: console

--- a/classwork/advanced-04-classwork.qmd
+++ b/classwork/advanced-04-classwork.qmd
@@ -1,5 +1,5 @@
 ---
-title: "3 - Grid Search via Racing - Classwork"
+title: "4 - Grid Search via Racing - Classwork"
 subtitle: "Advanced tidymodels"
 editor_options: 
   chunk_output_type: console

--- a/classwork/advanced-05-classwork.qmd
+++ b/classwork/advanced-05-classwork.qmd
@@ -1,5 +1,5 @@
 ---
-title: "4 - Iterative Search - Classwork"
+title: "5 - Iterative Search - Classwork"
 subtitle: "Advanced tidymodels"
 editor_options: 
   chunk_output_type: console


### PR DESCRIPTION
closes #250

only the number in the title of the classwork qmds were still off, the rest was already updated in https://github.com/tidymodels/workshops/pull/248