### PR TITLE
Update layout of "Our versions" slide to 4 columns

### DIFF
--- a/slides/advanced-01-introduction.qmd
+++ b/slides/advanced-01-introduction.qmd
@@ -286,7 +286,7 @@ df <- tibble::tibble(
 
 ids <- split(
   seq_len(nrow(df)), 
-  ceiling(seq_len(nrow(df)) / ceiling(nrow(df) / 3))
+  ceiling(seq_len(nrow(df)) / ceiling(nrow(df) / 4))
 )
 
 column1 <- df %>%
@@ -298,30 +298,41 @@ column2 <- df %>%
 column3 <- df %>%
   dplyr::slice(ids[[3]])
 
+column4 <- df %>%
+  dplyr::slice(ids[[4]])
+
 quarto_info <- paste0("Quarto (", system("quarto --version", intern = TRUE), ")")
 ```
 
 `r R.version.string`, `r quarto_info`
 
 ::: {.columns style="font-size:0.7em;"}
-::: {.column width="33%"}
+::: {.column width="25%"}
 ```{r}
 #| echo: false
 knitr::kable(column1)
 ```
 :::
 
-::: {.column width="33%"}
+::: {.column width="25%"}
 ```{r}
 #| echo: false
 knitr::kable(column2)
 ```
 :::
 
-::: {.column width="33%"}
+::: {.column width="25%"}
 ```{r}
 #| echo: false
 knitr::kable(column3)
 ```
 :::
+
+::: {.column width="25%"}
+```{r}
+#| echo: false
+knitr::kable(column4)
+```
 :::
+:::
+

--- a/slides/intro-01-introduction.qmd
+++ b/slides/intro-01-introduction.qmd
@@ -309,7 +309,7 @@ df <- tibble::tibble(
 
 ids <- split(
   seq_len(nrow(df)), 
-  ceiling(seq_len(nrow(df)) / ceiling(nrow(df) / 3))
+  ceiling(seq_len(nrow(df)) / ceiling(nrow(df) / 4))
 )
 
 column1 <- df %>%
@@ -321,30 +321,40 @@ column2 <- df %>%
 column3 <- df %>%
   dplyr::slice(ids[[3]])
 
+column4 <- df %>%
+  dplyr::slice(ids[[4]])
+
 quarto_info <- paste0("Quarto (", system("quarto --version", intern = TRUE), ")")
 ```
 
 `r R.version.string`, `r quarto_info`
 
 ::: {.columns style="font-size:0.7em;"}
-::: {.column width="33%"}
+::: {.column width="25%"}
 ```{r}
 #| echo: false
 knitr::kable(column1)
 ```
 :::
 
-::: {.column width="33%"}
+::: {.column width="25%"}
 ```{r}
 #| echo: false
 knitr::kable(column2)
 ```
 :::
 
-::: {.column width="33%"}
+::: {.column width="25%"}
 ```{r}
 #| echo: false
 knitr::kable(column3)
+```
+:::
+
+::: {.column width="25%"}
+```{r}
+#| echo: false
+knitr::kable(column4)
 ```
 :::
 :::


### PR DESCRIPTION
With the recent additions, the 3 columns got too long to fit on one slide.

For me, this renders fine for the intro course but looks wonky for the advanced course. Could you render locally and check how they both look for you? I didn't see what could have cause that difference.