### PR TITLE
Don't use "end of day discussion" on deck 4 of 6 already

### DIFF
--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -734,21 +734,3 @@ Use this for **prediction** on new data, like for deploying
 
 knitr::include_graphics("images/whole-game-final-performance.jpg")
 ```
-
-## Your turn {transition="slide-in"}
-
-![](images/parsnip-flagger.jpg){.absolute top="0" right="0" width="150" height="150"}
-
-*End of the day discussion!*
-
-*Which model do you think you would decide to use?*
-
-*What surprised you the most?*
-
-*If you're taking Advanced tidymodels tomorrow, what is one thing you are looking forward to learning?*
-
-```{r ex-discuss-which-model}
-#| echo: false
-countdown::countdown(minutes = 5, id = "discuss-which-model")
-```
-


### PR DESCRIPTION
This PR removes the last slide for deck 4:

This was a "Your turn" slide asking people about their thoughts on the day. That's a leftover from the 2-day format. Now we still have a tuning deck and a dedicated Wrapping Up deck to go in our plan (and the wrapping up deck asks the same question), so I removed that here and end this deck on the whole game diagram.