### PR TITLE
use mathjax

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -56,3 +56,7 @@ format:
     css: styles.css
 
 fig-format: svg
+
+html-math-method:
+  method: mathjax
+  url: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"


### PR DESCRIPTION
The equations look awful with the current version of Quarto (due to a pandoc issue). See https://github.com/quarto-dev/quarto-cli/discussions/3127#discussioncomment-4031511 and https://github.com/quarto-dev/quarto-cli/issues/5636

This PR uses a specific version of mathjax to solve the issue, 