### PR TITLE
transition from `taxi` to `forested`

### DIFF
--- a/classwork/extras-vetiver.qmd
+++ b/classwork/extras-vetiver.qmd
@@ -11,22 +11,23 @@ We recommend restarting R between each slide deck!
 
 ```{r}
 library(tidymodels)
+library(forested)
 
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 
 set.seed(123)
-taxi_folds <- vfold_cv(taxi_train, v = 10, strata = tip)
+forested_folds <- vfold_cv(forested_train, v = 10, strata = forested)
 
 tree_spec <-
   decision_tree() %>% 
   set_mode("classification")
 
 tree_fit <-
-  workflow(tip ~ ., tree_spec) %>% 
-  fit(data = taxi_train) 
+  workflow(forested ~ ., tree_spec) %>% 
+  fit(data = forested_train) 
 ```
 
 ## Your turn
@@ -38,7 +39,7 @@ library(vetiver)
 library(plumber)
 
 # Create a vetiver model object
-v <- vetiver_model(tree_fit, "taxi_tips")
+v <- vetiver_model(tree_fit, "forested")
 v
 ```
 

--- a/classwork/intro-02-classwork.qmd
+++ b/classwork/intro-02-classwork.qmd
@@ -7,12 +7,13 @@ editor_options:
 
 We recommend restarting R between each slide deck!
 
-## Data on taxi trips in Chicago in 2022
+## Data on forests in Washington
 
 ```{r}
 library(tidymodels)
+library(forested)
 
-taxi
+forested
 ```
 
 ## Your turn
@@ -24,22 +25,22 @@ When is a good time to split your data?
 ```{r}
 set.seed(123)
 
-taxi_split <- initial_split(taxi)
-taxi_split
+forested_split <- initial_split(forested)
+forested_split
 ```
 
 Extract the training and testing sets
 
 ```{r}
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 ```
 
 ## Validation set
 
 ```{r}
 set.seed(123)
-initial_validation_split(taxi, prop = c(0.6, 0.2))
+initial_validation_split(forested, prop = c(0.6, 0.2))
 ```
 
 ## Your turn
@@ -57,11 +58,11 @@ Hint: Which argument in `initial_split()` handles the proportion split into trai
 
 ## Your turn
 
-Explore the `taxi_train` data on your own!
+Explore the `forested_train` data on your own!
 
-- What's the distribution of the outcome, tip?
-- What's the distribution of numeric variables like distance?
-- How does tip differ across the categorical variables?
+* What's the distribution of the outcome, `forested`?
+* What's the distribution of numeric variables like `precip_annual`?
+* How does the distribution of `forested` differ across the categorical variables?
 
 ```{r}
 # Your code here!
@@ -73,7 +74,7 @@ Explore the `taxi_train` data on your own!
 ```{r}
 set.seed(123)
 
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 ```

--- a/classwork/intro-03-classwork.qmd
+++ b/classwork/intro-03-classwork.qmd
@@ -13,11 +13,12 @@ Setup from deck 2
 
 ```{r}
 library(tidymodels)
+library(forested)
 
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 ```
 
 ## Your turn
@@ -62,7 +63,7 @@ tree_spec
 
 ```{r}
 tree_spec <-
-  decision_tree(cost_complexity = 0.002) %>% 
+  decision_tree() %>% 
   set_mode("classification")
 ```
 
@@ -70,23 +71,23 @@ Fit parsnip specification:
 
 ```{r}
 tree_spec %>% 
-  fit(tip ~ ., data = taxi_train) 
+  fit(forested ~ ., data = forested_train) 
 ```
 
 Fit with a workflow:
 
 ```{r}
 workflow() %>%
-  add_formula(tip ~ .) %>%
+  add_formula(forested ~ .) %>%
   add_model(tree_spec) %>%
-  fit(data = taxi_train) 
+  fit(data = forested_train) 
 ```
 
 "Shortcut" by specifying the preprocessor and model spec directly in the `workflow()` call:
 
 ```{r}
-workflow(tip ~ ., tree_spec) %>% 
-  fit(data = taxi_train) 
+workflow(forested ~ ., tree_spec) %>% 
+  fit(data = forested_train) 
 ```
 
 ## Your turn
@@ -97,11 +98,11 @@ Extension/Challenge: Other than formulas, what kinds of preprocessors are suppor
 
 ```{r tree_wflow}
 tree_spec <-
-  decision_tree(cost_complexity = 0.002) %>% 
+  decision_tree() %>% 
   set_mode("classification")
 
 tree_wflow <- workflow() %>%
-  add_formula(tip ~ .) %>%
+  add_formula(forested ~ .) %>%
   add_model(tree_spec)
 
 tree_wflow
@@ -111,8 +112,8 @@ tree_wflow
 
 ```{r}
 tree_fit <-
-  workflow(tip ~ ., tree_spec) %>% 
-  fit(data = taxi_train) 
+  workflow(forested ~ ., tree_spec) %>% 
+  fit(data = forested_train) 
 ```
 
 ## Your turn
@@ -120,7 +121,7 @@ tree_fit <-
 What do you get from running the following code? What do you notice about the structure of the result?
 
 ```{r}
-predict(tree_fit, new_data = taxi_test)
+predict(tree_fit, new_data = forested_test)
 ```
 
 ## Your turn
@@ -128,7 +129,7 @@ predict(tree_fit, new_data = taxi_test)
 What do you get from running the following code? How is `augment()` different from `predict()`?
 
 ```{r}
-augment(tree_fit, new_data = taxi_test)
+augment(tree_fit, new_data = forested_test)
 ```
 
 ## Understand your model

--- a/classwork/intro-04-classwork.qmd
+++ b/classwork/intro-04-classwork.qmd
@@ -53,7 +53,7 @@ All yardstick metric functions work with grouped data frames!
 
 ```{r}
 augment(forested_fit, new_data = forested_train) %>%
-  group_by(local) %>%
+  group_by(tree_no_tree) %>%
   accuracy(truth = forested, estimate = .pred_class)
 ```
 

--- a/classwork/intro-04-classwork.qmd
+++ b/classwork/intro-04-classwork.qmd
@@ -13,15 +13,16 @@ Setup from deck 3
 
 ```{r}
 library(tidymodels)
+library(forested)
 
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 
 tree_spec <- decision_tree(cost_complexity = 0.0001, mode = "classification")
-taxi_wflow <- workflow(tip ~ ., tree_spec)
-taxi_fit <- fit(taxi_wflow, taxi_train)
+forested_wflow <- workflow(forested ~ ., tree_spec)
+forested_fit <- fit(forested_wflow, forested_train)
 ```
 
 ## Metrics for model performance
@@ -29,40 +30,40 @@ taxi_fit <- fit(taxi_wflow, taxi_train)
 `conf_mat()` can be used to see how well the model is doing at prediction
 
 ```{r}
-augment(taxi_fit, new_data = taxi_train) %>%
-  conf_mat(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  conf_mat(truth = forested, estimate = .pred_class)
 ```
 
 and it has nice plotting features
 
 ```{r}
-augment(taxi_fit, new_data = taxi_train) %>%
-  conf_mat(truth = tip, estimate = .pred_class) %>%
+augment(forested_fit, new_data = forested_train) %>%
+  conf_mat(truth = forested, estimate = .pred_class) %>%
   autoplot(type = "heatmap")
 ```
 
 using the same interface we can calculate metrics
 
 ```{r}
-augment(taxi_fit, new_data = taxi_train) %>%
-  accuracy(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  accuracy(truth = forested, estimate = .pred_class)
 ```
 
 All yardstick metric functions work with grouped data frames!
 
 ```{r}
-augment(taxi_fit, new_data = taxi_train) %>%
+augment(forested_fit, new_data = forested_train) %>%
   group_by(local) %>%
-  accuracy(truth = tip, estimate = .pred_class)
+  accuracy(truth = forested, estimate = .pred_class)
 ```
 
 Metric sets are a way to combine multiple similar metric functions together into a new function.
 
 ```{r}
-taxi_metrics <- metric_set(accuracy, specificity, sensitivity)
+forested_metrics <- metric_set(accuracy, specificity, sensitivity)
 
-augment(taxi_fit, new_data = taxi_train) %>%
-  taxi_metrics(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  forested_metrics(truth = forested, estimate = .pred_class)
 ```
 
 ## Your turn
@@ -81,24 +82,24 @@ What data are being used for this ROC curve plot?
 Repredicting the training set, bad!
 
 ```{r}
-taxi_fit %>%
-  augment(taxi_train)
+forested_fit %>%
+  augment(forested_train)
 ```
 
 "Resubstitution estimate" - This should be the best possible performance that you could ever achieve, but it can be very misleading!
 
 ```{r}
-taxi_fit %>%
-  augment(taxi_train) %>%
-  accuracy(tip, .pred_class)
+forested_fit %>%
+  augment(forested_train) %>%
+  accuracy(forested, .pred_class)
 ```
 
 Now on the test set, see that it performs worse? This is closer to "real" performance.
 
 ```{r}
-taxi_fit %>%
-  augment(taxi_test) %>%
-  accuracy(tip, .pred_class)
+forested_fit %>%
+  augment(forested_test) %>%
+  accuracy(forested, .pred_class)
 ```
 
 ## Your turn
@@ -112,8 +113,8 @@ Notice the evidence of overfitting!
 ```{r}
 # Your code here!
 
-# Use `augment()` and `brier_class()` with `taxi_fit`
-taxi_fit
+# Use `augment()` and `brier_class()` with `forested_fit`
+forested_fit
 ```
 
 ## Your turn
@@ -129,30 +130,30 @@ for each fold
 
 ```{r}
 # v = 10 is the default
-vfold_cv(taxi_train)
+vfold_cv(forested_train)
 ```
 
 What is in a resampling result?
 
 ```{r}
-taxi_folds <- vfold_cv(taxi_train, v = 10)
+forested_folds <- vfold_cv(forested_train, v = 10)
 
 # Individual splits of analysis/assessment data
-taxi_folds$splits[1:3]
+forested_folds$splits[1:3]
 ```
 
 Stratification often helps, with very little downside
 
 ```{r}
-vfold_cv(taxi_train, strata = tip)
+vfold_cv(forested_train, strata = forested)
 ```
 
 We'll use this setup:
 
 ```{r}
 set.seed(123)
-taxi_folds <- vfold_cv(taxi_train, v = 10, strata = tip)
-taxi_folds
+forested_folds <- vfold_cv(forested_train, v = 10, strata = forested)
+forested_folds
 ```
 
 ## Evaluating model performance
@@ -160,14 +161,14 @@ taxi_folds
 ```{r}
 # Fit the workflow on each analysis set,
 # then compute performance on each assessment set
-taxi_res <- fit_resamples(taxi_wflow, taxi_folds)
-taxi_res
+forested_res <- fit_resamples(forested_wflow, forested_folds)
+forested_res
 ```
 
 Aggregate metrics
 
 ```{r}
-taxi_res %>%
+forested_res %>%
   collect_metrics()
 ```
 
@@ -175,19 +176,19 @@ If you want to analyze the assessment set (i.e. holdout) predictions, then you n
 
 ```{r}
 # Save the assessment set results
-ctrl_taxi <- control_resamples(save_pred = TRUE)
+ctrl_forested <- control_resamples(save_pred = TRUE)
 
-taxi_res <- fit_resamples(taxi_wflow, taxi_folds, control = ctrl_taxi)
+forested_res <- fit_resamples(forested_wflow, forested_folds, control = ctrl_forested)
 
-taxi_preds <- collect_predictions(taxi_res)
-taxi_preds
+forested_preds <- collect_predictions(forested_res)
+forested_preds
 ```
 
 ## Bootstrapping
 
 ```{r}
 set.seed(3214)
-bootstraps(taxi_train)
+bootstraps(forested_train)
 ```
 
 ## Your turn
@@ -216,7 +217,7 @@ rf_spec
 ```
 
 ```{r}
-rf_wflow <- workflow(tip ~ ., rf_spec)
+rf_wflow <- workflow(forested ~ ., rf_spec)
 rf_wflow
 ```
 
@@ -235,13 +236,13 @@ Use `fit_resamples()` and `rf_wflow` to:
 ## Evaluate a workflow set
 
 ```{r}
-wf_set <- workflow_set(list(tip ~ .), list(tree_spec, rf_spec))
+wf_set <- workflow_set(list(forested ~ .), list(tree_spec, rf_spec))
 wf_set
 ```
 
 ```{r}
 wf_set_fit <- wf_set %>%
-  workflow_map("fit_resamples", resamples = taxi_folds)
+  workflow_map("fit_resamples", resamples = forested_folds)
 
 wf_set_fit
 ```
@@ -262,8 +263,8 @@ Discuss with your neighbors!
 ## The final fit
 
 ```{r}
-# `taxi_split` has train + test info
-final_fit <- last_fit(rf_wflow, taxi_split) 
+# `forested_split` has train + test info
+final_fit <- last_fit(rf_wflow, forested_split) 
 
 final_fit
 ```
@@ -282,7 +283,7 @@ collect_predictions(final_fit)
 
 ```{r}
 collect_predictions(final_fit) %>%
-  ggplot(aes(.pred_class, fill = tip)) + 
+  ggplot(aes(.pred_class, fill = forested)) + 
   geom_bar() 
 ```
 

--- a/classwork/intro-05-classwork.qmd
+++ b/classwork/intro-05-classwork.qmd
@@ -13,14 +13,15 @@ Setup from deck 3
 
 ```{r}
 library(tidymodels)
+library(forested)
 
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 
 set.seed(123)
-taxi_folds <- vfold_cv(taxi_train, v = 10, strata = tip)
+forested_folds <- vfold_cv(forested_train, v = 10, strata = forested)
 ```
 
 ## Tag parameters for tuning
@@ -29,7 +30,7 @@ taxi_folds <- vfold_cv(taxi_train, v = 10, strata = tip)
 rf_spec <- rand_forest(min_n = tune()) %>% 
   set_mode("classification")
 
-rf_wflow <- workflow(tip ~ ., rf_spec)
+rf_wflow <- workflow(forested ~ ., rf_spec)
 rf_wflow
 ```
 
@@ -39,7 +40,7 @@ rf_wflow
 set.seed(22)
 rf_res <- tune_grid(
   rf_wflow,
-  taxi_folds,
+  forested_folds,
   grid = 5
 )
 ```
@@ -58,7 +59,7 @@ best_parameter
 ```{r}
 rf_wflow <- finalize_workflow(rf_wflow, best_parameter)
 
-final_fit <- last_fit(rf_wflow, taxi_split) 
+final_fit <- last_fit(rf_wflow, forested_split) 
 
 collect_metrics(final_fit)
 ```

--- a/classwork/intro-extra-recipes-classwork.qmd
+++ b/classwork/intro-extra-recipes-classwork.qmd
@@ -13,11 +13,12 @@ Setup from deck 3
 
 ```{r}
 library(tidymodels)
+library(forested)
 
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 ```
 
 ## Your turn
@@ -29,12 +30,12 @@ Take the recipe and `prep()` then `bake()` it to see what the resulting data set
 Try removing steps to see how the results changes.
 
 ```{r}
-rec_spec <- recipe(tip ~ ., data = taxi_train) %>%  
+rec_spec <- recipe(forested ~ ., data = forested_train) %>%  
   step_unknown(all_nominal_predictors()) %>%  
   step_other(all_nominal_predictors()) %>%  
   step_dummy(all_nominal_predictors()) %>%  
   step_zv(all_predictors()) %>%  
-  step_log(distance, offset = 0.5) %>% 
+  step_log(canopy_cover, offset = 0.5) %>% 
   step_normalize(all_numeric_predictors())
 ```
 

--- a/slides/extras-vetiver.qmd
+++ b/slides/extras-vetiver.qmd
@@ -30,25 +30,26 @@ knitr:
 ```{r setup-previous}
 #| echo: false
 library(tidymodels)
+library(forested)
 
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 
 tree_spec <- decision_tree(cost_complexity = 0.0001, mode = "classification")
-tree_fit <- workflow(tip ~ ., tree_spec) %>% fit(taxi_train)
+tree_fit <- workflow(forested ~ ., tree_spec) %>% fit(forested_train)
 ```
 
 ## Deploying a model `r hexes("vetiver")`
 
-We have a decision tree, `tree_fit`, to model whether or not a taxi trip in Chicago included a tip or not.
+We have a decision tree, `tree_fit`, to model whether or not a forested trip in Chicago included a forested or not.
 
 How do we use our model in **production**?
 
 ```{r tree-vetiver}
 library(vetiver)
-v <- vetiver_model(tree_fit, "taxi")
+v <- vetiver_model(tree_fit, "forested")
 v
 ```
 

--- a/slides/extras-vetiver.qmd
+++ b/slides/extras-vetiver.qmd
@@ -43,7 +43,7 @@ tree_fit <- workflow(forested ~ ., tree_spec) %>% fit(forested_train)
 
 ## Deploying a model `r hexes("vetiver")`
 
-We have a decision tree, `tree_fit`, to model whether or not a forested trip in Chicago included a forested or not.
+We have a decision tree, `tree_fit`, to model whether or not a plot of land in Washington is forested or not.
 
 How do we use our model in **production**?
 

--- a/slides/intro-02-data-budget.qmd
+++ b/slides/intro-02-data-budget.qmd
@@ -26,13 +26,13 @@ knitr:
 ##  {background-image="https://media.giphy.com/media/Lr3UeH9tYu3qJtsSUg/giphy.gif" background-size="40%"}
 
 
-## Data on Chicago taxi trips
+## Data on forests in Washington
 
 ::: columns
 ::: {.column width="60%"}
--   The city of Chicago releases anonymized trip-level data on taxi trips in the city.
--   We pulled a sample of 10,000 rides occurring in early 2022.
--   Type `?taxi` to learn more about this dataset, including references.
+-   The U.S. Forest Service maintains ML models to predict whether a plot of land is "forested."
+-   This classification is important for all sorts of research, legislation, and land management purposes.
+-   Type `?forested` to learn more about this dataset, including references.
 :::
 
 ::: {.column width="40%"}
@@ -42,17 +42,18 @@ knitr:
 :::
 
 ::: footer
-Credit: <https://www.svgrepo.com/svg/8322/taxi>
+Credit: <https://www.svgrepo.com/svg/8322/forested>
 :::
 
-## Data on Chicago taxi trips
+## Data on forests in Washington
 
 ::: columns
 ::: {.column width="60%"}
--   `N = 10,000`
--   A nominal outcome, `tip`, with levels `"yes"` and `"no"`
--   Several **nominal** variables like pickup & dropoff location, taxi ID, and payment type.
--   Several **numeric** variables like trip length and fare subtotals.
+-   `N = 7,109` plots of land, one from each of 7,109 6000-acre hexagons in WA.
+-   A nominal outcome, `forested`, with levels `"Yes"` and `"No"`, measured "on-the-ground."
+-   18 remotely-sensed and easily-accessible predictors:
+     - **numeric** variables based on weather and topography.
+     - **nominal** variables based on classifications from other governmental orgs.
 :::
 
 ::: {.column width="40%"}
@@ -65,25 +66,7 @@ Credit: <https://unsplash.com/photos/7_r85l4eht8>
 :::
 
 :::notes
-
-"Fare subtotals" refers to the fare itself, tax, tolls, tip amount. 
-
-Actual variables in our data:
-
-`tip`: Whether the rider left a tip. A factor with levels "yes" and "no".
-
-`distance`: The trip distance, in odometer miles.
-
-`company`: The taxi company, as a factor. Companies that occurred few times were binned as "other".
-
-`local`: Whether the trip started in the same community area as it began. See the source data for community area values.
-
-`dow`: The day of the week in which the trip began, as a factor.
-
-`month`: The month in which the trip began, as a factor.
-
-`hour`: The hour of the day in which the trip began, as a numeric.
-
+- Those nominal variables are classifications similar to "forested" but from other agencies. e.g. `land_type` is from the European Space Agency, and is a remotely-sensed 3-class distribution based on predictions for how the land is used.
 :::
 
 ## Checklist for predictors
@@ -94,13 +77,17 @@ Actual variables in our data:
 
 - Does this variable contribute to explainability?
 
+:::notes
+- re: ethics -- what issues might arise from releasing the true `lat` and `lon`? In reality, these `lat` and `lon` are slightly jittered to help ensure trust with landowners who allow surveyers to come take measurements.
+:::
 
-## Data on Chicago taxi trips
+## Data on forests in Washington
 
-```{r taxi-print}
+```{r forested-print}
 library(tidymodels)
+library(forested)
 
-taxi
+forested
 ```
 
 
@@ -126,7 +113,7 @@ Do not 🚫 use the test set during training.
 #| 
 set.seed(123)
 library(forcats)
-one_split <- slice(taxi, 1:30) %>% 
+one_split <- slice(forested, 1:30) %>% 
   initial_split() %>% 
   tidy() %>% 
   add_row(Row = 1:30, Data = "Original") %>% 
@@ -176,10 +163,10 @@ countdown::countdown(minutes = 3, id = "when-to-split")
 
 ## The initial split `r hexes("rsample")` {.annotation}
 
-```{r taxi-split}
+```{r forested-split}
 set.seed(123)
-taxi_split <- initial_split(taxi)
-taxi_split
+forested_split <- initial_split(forested)
+forested_split
 ```
 
 :::notes
@@ -198,15 +185,15 @@ Which seed you pick doesn't matter, as long as you don't try a bunch of seeds an
 
 ## Accessing the data `r hexes("rsample")`
 
-```{r taxi-train-test}
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+```{r forested-train-test}
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 ```
 
 ## The training set`r hexes("rsample")`
 
-```{r taxi-train}
-taxi_train
+```{r forested-train}
+forested_train
 ```
 
 ## The test set `r hexes("rsample")`
@@ -215,7 +202,7 @@ taxi_train
 
 . . .
 
-There are `r nrow(taxi_test)` rows and `r ncol(taxi_test)` columns in the test set.
+There are `r nrow(forested_test)` rows and `r ncol(forested_test)` columns in the test set.
 
 ## Your turn {transition="slide-in"}
 
@@ -232,14 +219,14 @@ countdown::countdown(minutes = 5, id = "try-splitting")
 
 ## Data splitting and spending `r hexes("rsample")`
 
-```{r taxi-split-prop}
+```{r forested-split-prop}
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 
-nrow(taxi_train)
-nrow(taxi_test)
+nrow(forested_train)
+nrow(forested_test)
 ```
 
 # What about a validation set?
@@ -250,7 +237,7 @@ nrow(taxi_test)
 
 ```{r}
 set.seed(123)
-initial_validation_split(taxi, prop = c(0.6, 0.2))
+initial_validation_split(forested, prop = c(0.6, 0.2))
 ```
 
 # Exploratory data analysis for ML 🧐
@@ -259,15 +246,15 @@ initial_validation_split(taxi, prop = c(0.6, 0.2))
 
 ![](images/parsnip-flagger.jpg){.absolute top="0" right="0" width="150" height="150"}
 
-*Explore the `taxi_train` data on your own!*
+*Explore the `forested_train` data on your own!*
 
-* *What's the distribution of the outcome, `tip`?*
-* *What's the distribution of numeric variables like `distance`?*
-* *How does `tip` differ across the categorical variables?*
+* *What's the distribution of the outcome, `forested`?*
+* *What's the distribution of numeric variables like `precip_annual`?*
+* *How does the distribution of `forested` differ across the categorical variables?*
 
-```{r ex-explore-taxi}
+```{r ex-explore-forested}
 #| echo: false
-countdown::countdown(minutes = 8, id = "explore-taxi")
+countdown::countdown(minutes = 8, id = "explore-forested")
 ```
 
 ::: notes
@@ -276,89 +263,103 @@ Make a plot or summary and then share with neighbor
 
 ## 
 
-```{r taxi-tip-counts}
+```{r forested-forested-counts}
 #| fig-align: 'center'
-taxi_train %>% 
-  ggplot(aes(x = tip)) +
+forested_train %>% 
+  ggplot(aes(x = forested)) +
   geom_bar()
 ```
 
 ## 
 
-```{r taxi-tip-by-local}
+```{r forested-by-tree-no-tree}
 #| fig-align: 'center'
-taxi_train %>% 
-  ggplot(aes(x = tip, fill = local)) +
+forested_train %>% 
+  ggplot(aes(x = forested, fill = tree_no_tree)) +
   geom_bar() +
   scale_fill_viridis_d(end = .5)
 ```
 
 ## 
 
-```{r taxi-tip-by-hour}
+```{r forested-by-precip-annual}
 #| fig-align: 'center'
-taxi_train %>% 
-  ggplot(aes(x = hour, fill = tip)) +
-  geom_bar()
+#| message: false
+#| warning: false
+forested_train %>% 
+  ggplot(aes(x = precip_annual, fill = forested, group = forested)) +
+  geom_histogram() +
+  scale_fill_viridis_d(end = .5)
+```
+
+<!-- TODO: should we `position = "identity", alpha = .5` here? -->
+
+## 
+
+```{r forested-by-precip-annual-fill}
+#| fig-align: 'center'
+#| message: false
+#| warning: false
+forested_train %>% 
+  ggplot(aes(x = precip_annual, fill = forested, group = forested)) +
+  geom_histogram(position = "fill") +
+  scale_fill_viridis_d(end = .5)
 ```
 
 ## 
 
-```{r taxi-tip-by-hour-fill}
+```{r forested-forested-by-lat-lon}
 #| fig-align: 'center'
-taxi_train %>% 
-  ggplot(aes(x = hour, fill = tip)) +
-  geom_bar(position = "fill")
+forested_train %>% 
+  ggplot(aes(x = lon, y = lat, col = forested)) +
+  geom_point() + 
+  scale_color_viridis_d(end = .5)
 ```
 
-## 
-
-```{r taxi-tip-by-distance}
-#| fig-align: 'center'
-taxi_train %>% 
-  ggplot(aes(x = distance)) +
-  geom_histogram(bins = 100) +
-  facet_grid(vars(tip))
-```
+TODO: should we lean into a `forested` color scheme and have green for forested, tan for not?
 
 # Split smarter
 
 ##
 
-```{r taxi-tip-pct, echo = FALSE}
-taxi %>%
-  ggplot(aes(x = "", fill = tip)) +
+```{r forested-forested-pct, echo = FALSE}
+forested %>%
+  ggplot(aes(x = "", fill = forested)) +
   geom_bar(position = "fill") +
-  labs(x = "")
+  labs(x = "") + 
+  scale_fill_viridis_d(end = .5)
 ```
 
 Stratified sampling would split within response values
 
 :::notes
-Based on our EDA, we know that the source data contains fewer `"no"` tip values than `"yes"`. We want to make sure we allot equal proportions of those responses so that both the training and testing data have enough of each to give accurate estimates.
+Based on our EDA, we know that the source data contains fewer `"No"` forested values than `"Yes"`. We want to make sure we allot equal proportions of those responses so that both the training and testing data have enough of each to give accurate estimates.
+
+TODO: this class imbalance is much less present with forested vs taxi -- should we keep it around?
 :::
 
 ## Stratification
 
-Use `strata = tip`
+Use `strata = forested`
 
-```{r taxi-split-prop-strata}
+```{r forested-split-prop-strata}
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_split
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_split
 ```
 
 ## Stratification
 
 Stratification often helps, with very little downside
 
-```{r taxi-tip-pct-by-split, echo = FALSE}
+```{r forested-forested-pct-by-split, echo = FALSE}
 bind_rows(
-  taxi_train %>% mutate(split = "train"),
-  taxi_test %>% mutate(split = "test")
+  forested_train %>% mutate(split = "train"),
+  forested_test %>% mutate(split = "test")
 ) %>%
-  ggplot(aes(x = split, fill = tip)) +
-  geom_bar(position = "fill")
+  ggplot(aes(x = split, fill = forested)) +
+  geom_bar(position = "fill") + 
+  scale_fill_viridis_d(end = .5)
 ```
 
 ## The whole game - status update

--- a/slides/intro-02-data-budget.qmd
+++ b/slides/intro-02-data-budget.qmd
@@ -32,6 +32,7 @@ knitr:
 ::: {.column width="60%"}
 -   The U.S. Forest Service maintains ML models to predict whether a plot of land is "forested."
 -   This classification is important for all sorts of research, legislation, and land management purposes.
+-  Plots are typically remeasured every 10 years and this dataset contains the most recent measurement per plot.
 -   Type `?forested` to learn more about this dataset, including references.
 :::
 
@@ -113,7 +114,7 @@ Do not 🚫 use the test set during training.
 #| 
 set.seed(123)
 library(forcats)
-one_split <- slice(forested, 1:30) %>% 
+one_split <- tibble(x = 1:30) %>% 
   initial_split() %>% 
   tidy() %>% 
   add_row(Row = 1:30, Data = "Original") %>% 

--- a/slides/intro-02-data-budget.qmd
+++ b/slides/intro-02-data-budget.qmd
@@ -42,7 +42,7 @@ knitr:
 :::
 
 ::: footer
-Credit: <https://www.svgrepo.com/svg/8322/forested>
+Credit: <https://www.svgrepo.com/svg/8322/taxi>
 :::
 
 ## Data on forests in Washington
@@ -288,7 +288,7 @@ forested_train %>%
 #| warning: false
 forested_train %>% 
   ggplot(aes(x = precip_annual, fill = forested, group = forested)) +
-  geom_histogram() +
+  geom_histogram(position = "identity", alpha = .5) +
   scale_fill_viridis_d(end = .5)
 ```
 

--- a/slides/intro-02-data-budget.qmd
+++ b/slides/intro-02-data-budget.qmd
@@ -293,8 +293,6 @@ forested_train %>%
   scale_fill_viridis_d(end = .5)
 ```
 
-<!-- TODO: should we `position = "identity", alpha = .5` here? -->
-
 ## 
 
 ```{r forested-by-precip-annual-fill}

--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -71,12 +71,13 @@ countdown::countdown(minutes = 3, id = "how-to-fit-linear-model")
 ```{r setup-previous}
 #| echo: false
 library(tidymodels)
+library(forested)
 
 set.seed(123)
 
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 ```
 
 ```{r logistic-reg}
@@ -98,7 +99,7 @@ Models have default engines
 :::
 
 ::: {.column width="60%"}
-![](images/taxi_spinning.svg)
+![](images/forested_spinning.svg)
 :::
 :::
 
@@ -126,7 +127,7 @@ logistic_reg() %>%
 :::
 
 ::: {.column width="60%"}
-![](images/taxi_spinning.svg)
+![](images/forested_spinning.svg)
 :::
 :::
 
@@ -171,7 +172,7 @@ All available models are listed at <https://www.tidymodels.org/find/parsnip/>
 :::
 
 ::: {.column width="60%"}
-![](images/taxi_spinning.svg)
+![](images/forested_spinning.svg)
 :::
 :::
 
@@ -466,35 +467,35 @@ Two ways workflows handle levels better than base R:
 
 ```{r tree-spec}
 tree_spec <-
-  decision_tree(cost_complexity = 0.002) %>% 
+  decision_tree() %>% 
   set_mode("classification")
 
 tree_spec %>% 
-  fit(tip ~ ., data = taxi_train) 
+  fit(forested ~ ., data = forested_train) 
 ```
 
 ## A model workflow `r hexes("parsnip", "workflows")`
 
 ```{r tree-wflow}
 tree_spec <-
-  decision_tree(cost_complexity = 0.002) %>% 
+  decision_tree() %>% 
   set_mode("classification")
 
 workflow() %>%
-  add_formula(tip ~ .) %>%
+  add_formula(forested ~ .) %>%
   add_model(tree_spec) %>%
-  fit(data = taxi_train) 
+  fit(data = forested_train) 
 ```
 
 ## A model workflow `r hexes("parsnip", "workflows")`
 
 ```{r tree-wflow-fit}
 tree_spec <-
-  decision_tree(cost_complexity = 0.002) %>% 
+  decision_tree() %>% 
   set_mode("classification")
 
-workflow(tip ~ ., tree_spec) %>% 
-  fit(data = taxi_train) 
+workflow(forested ~ ., tree_spec) %>% 
+  fit(data = forested_train) 
 ```
 
 ## Your turn {transition="slide-in"}
@@ -520,12 +521,12 @@ How do you use your new `tree_fit` model?
 
 ```{r tree-wflow-fit-2}
 tree_spec <-
-  decision_tree(cost_complexity = 0.002) %>% 
+  decision_tree() %>% 
   set_mode("classification")
 
 tree_fit <-
-  workflow(tip ~ ., tree_spec) %>% 
-  fit(data = taxi_train) 
+  workflow(forested ~ ., tree_spec) %>% 
+  fit(data = forested_train) 
 ```
 
 ## Your turn {transition="slide-in"}
@@ -534,7 +535,7 @@ tree_fit <-
 
 *Run:*
 
-`predict(tree_fit, new_data = taxi_test)`
+`predict(tree_fit, new_data = forested_test)`
 
 *What do you get?*
 
@@ -549,7 +550,7 @@ countdown::countdown(minutes = 3, id = "predict-tree-fit")
 
 *Run:*
 
-`augment(tree_fit, new_data = taxi_test)`
+`augment(tree_fit, new_data = forested_test)`
 
 *What do you get?*
 

--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -99,7 +99,7 @@ Models have default engines
 :::
 
 ::: {.column width="60%"}
-![](images/forested_spinning.svg)
+![](images/taxi_spinning.svg)
 :::
 :::
 
@@ -127,7 +127,7 @@ logistic_reg() %>%
 :::
 
 ::: {.column width="60%"}
-![](images/forested_spinning.svg)
+![](images/taxi_spinning.svg)
 :::
 :::
 
@@ -172,7 +172,7 @@ All available models are listed at <https://www.tidymodels.org/find/parsnip/>
 :::
 
 ::: {.column width="60%"}
-![](images/forested_spinning.svg)
+![](images/taxi_spinning.svg)
 :::
 :::
 

--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -41,8 +41,7 @@ forested_fit <- fit(forested_wflow, forested_train)
 ```
 
 ```{r forested-fit-augment}
-augment(forested_fit, new_data = forested_train) %>%
-  relocate(forested, .pred_class, .pred_Yes, .pred_No)
+augment(forested_fit, new_data = forested_train)
 ```
 
 ## Confusion matrix `r hexes("yardstick")`

--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -28,20 +28,21 @@ knitr:
 ```{r setup-previous}
 #| echo: false
 library(tidymodels)
+library(forested)
 
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 
 tree_spec <- decision_tree(cost_complexity = 0.0001, mode = "classification")
-taxi_wflow <- workflow(tip ~ ., tree_spec)
-taxi_fit <- fit(taxi_wflow, taxi_train)
+forested_wflow <- workflow(forested ~ ., tree_spec)
+forested_fit <- fit(forested_wflow, forested_train)
 ```
 
-```{r taxi-fit-augment}
-augment(taxi_fit, new_data = taxi_train) %>%
-  relocate(tip, .pred_class, .pred_yes, .pred_no)
+```{r forested-fit-augment}
+augment(forested_fit, new_data = forested_train) %>%
+  relocate(forested, .pred_class, .pred_Yes, .pred_No)
 ```
 
 ## Confusion matrix `r hexes("yardstick")`
@@ -51,15 +52,15 @@ augment(taxi_fit, new_data = taxi_train) %>%
 ## Confusion matrix `r hexes("yardstick")`
 
 ```{r conf-mat}
-augment(taxi_fit, new_data = taxi_train) %>%
-  conf_mat(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  conf_mat(truth = forested, estimate = .pred_class)
 ```
 
 ## Confusion matrix `r hexes("yardstick")`
 
 ```{r conf-mat-plot}
-augment(taxi_fit, new_data = taxi_train) %>%
-  conf_mat(truth = tip, estimate = .pred_class) %>%
+augment(forested_fit, new_data = forested_train) %>%
+  conf_mat(truth = forested, estimate = .pred_class) %>%
   autoplot(type = "heatmap")
 ```
 
@@ -68,8 +69,8 @@ augment(taxi_fit, new_data = taxi_train) %>%
 ::: columns
 ::: {.column width="60%"}
 ```{r acc}
-augment(taxi_fit, new_data = taxi_train) %>%
-  accuracy(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  accuracy(truth = forested, estimate = .pred_class)
 ```
 :::
 
@@ -83,18 +84,20 @@ augment(taxi_fit, new_data = taxi_train) %>%
 We need to be careful of using `accuracy()` since it can give "good" performance by only predicting one way with imbalanced data
 
 ```{r acc-2}
-augment(taxi_fit, new_data = taxi_train) %>%
-  mutate(.pred_class = factor("yes", levels = c("yes", "no"))) %>%
-  accuracy(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  mutate(.pred_class = factor("Yes", levels = c("Yes", "No"))) %>%
+  accuracy(truth = forested, estimate = .pred_class)
 ```
+
+<!-- TODO: do we need to adjust this now that classes are relatively balanced? -->
 
 ## Metrics for model performance `r hexes("yardstick")`
 
 ::: columns
 ::: {.column width="60%"}
 ```{r sens}
-augment(taxi_fit, new_data = taxi_train) %>%
-  sensitivity(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  sensitivity(truth = forested, estimate = .pred_class)
 ```
 :::
 
@@ -110,15 +113,15 @@ augment(taxi_fit, new_data = taxi_train) %>%
 ::: {.column width="60%"}
 ```{r sens-2}
 #| code-line-numbers: "3-6"
-augment(taxi_fit, new_data = taxi_train) %>%
-  sensitivity(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  sensitivity(truth = forested, estimate = .pred_class)
 ```
 
 <br>
 
 ```{r spec}
-augment(taxi_fit, new_data = taxi_train) %>%
-  specificity(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  specificity(truth = forested, estimate = .pred_class)
 ```
 :::
 
@@ -131,21 +134,21 @@ augment(taxi_fit, new_data = taxi_train) %>%
 
 We can use `metric_set()` to combine multiple calculations into one
 
-```{r taxi-metrics}
-taxi_metrics <- metric_set(accuracy, specificity, sensitivity)
+```{r forested-metrics}
+forested_metrics <- metric_set(accuracy, specificity, sensitivity)
 
-augment(taxi_fit, new_data = taxi_train) %>%
-  taxi_metrics(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  forested_metrics(truth = forested, estimate = .pred_class)
 ```
 
 ## Metrics for model performance `r hexes("yardstick")`
 
-```{r taxi-metrics-grouped}
-taxi_metrics <- metric_set(accuracy, specificity, sensitivity)
+```{r forested-metrics-grouped}
+forested_metrics <- metric_set(accuracy, specificity, sensitivity)
 
-augment(taxi_fit, new_data = taxi_train) %>%
-  group_by(local) %>%
-  taxi_metrics(truth = tip, estimate = .pred_class)
+augment(forested_fit, new_data = forested_train) %>%
+  group_by(tree_no_tree) %>%
+  forested_metrics(truth = forested, estimate = .pred_class)
 ```
 
 ## Two class data
@@ -172,8 +175,8 @@ What happens for a 20% threshold?
 #| label: thresholds
 #| echo: false
 
-augment(taxi_fit, new_data = taxi_train) %>% 
-  roc_curve(truth = tip, .pred_yes) %>% 
+augment(forested_fit, new_data = forested_train) %>% 
+  roc_curve(truth = forested, .pred_Yes) %>% 
   filter(is.finite(.threshold)) %>% 
   pivot_longer(c(specificity, sensitivity), names_to = "statistic", values_to = "value") %>% 
   rename(`event threshold` = .threshold) %>% 
@@ -210,12 +213,12 @@ ROC curves are insensitive to class imbalance.
 
 ```{r roc-auc}
 # Assumes _first_ factor level is event; there are options to change that
-augment(taxi_fit, new_data = taxi_train) %>% 
-  roc_curve(truth = tip, .pred_yes) %>%
+augment(forested_fit, new_data = forested_train) %>% 
+  roc_curve(truth = forested, .pred_Yes) %>%
   slice(1, 20, 50)
 
-augment(taxi_fit, new_data = taxi_train) %>% 
-  roc_auc(truth = tip, .pred_yes)
+augment(forested_fit, new_data = forested_train) %>% 
+  roc_auc(truth = forested, .pred_Yes)
 ```
 
 ## ROC curve plot `r hexes("yardstick")`
@@ -225,8 +228,8 @@ augment(taxi_fit, new_data = taxi_train) %>%
 #| fig-height: 6
 #| output-location: "column"
 
-augment(taxi_fit, new_data = taxi_train) %>% 
-  roc_curve(truth = tip, .pred_yes) %>%
+augment(forested_fit, new_data = forested_train) %>% 
+  roc_curve(truth = forested, .pred_Yes) %>%
   autoplot()
 ```
 
@@ -261,8 +264,8 @@ countdown::countdown(minutes = 5, id = "roc-curve")
 ## Dangers of overfitting ⚠️ `r hexes("yardstick")`
 
 ```{r augment-train}
-taxi_fit %>%
-  augment(taxi_train)
+forested_fit %>%
+  augment(forested_train)
 ```
 
 We call this "resubstitution" or "repredicting the training set"
@@ -270,9 +273,9 @@ We call this "resubstitution" or "repredicting the training set"
 ## Dangers of overfitting ⚠️ `r hexes("yardstick")`
 
 ```{r augment-acc}
-taxi_fit %>%
-  augment(taxi_train) %>%
-  accuracy(tip, .pred_class)
+forested_fit %>%
+  augment(forested_train) %>%
+  accuracy(forested, .pred_class)
 ```
 
 We call this a "resubstitution estimate"
@@ -282,9 +285,9 @@ We call this a "resubstitution estimate"
 ::: columns
 ::: {.column width="50%"}
 ```{r augment-acc-2}
-taxi_fit %>%
-  augment(taxi_train) %>%
-  accuracy(tip, .pred_class)
+forested_fit %>%
+  augment(forested_train) %>%
+  accuracy(forested, .pred_class)
 ```
 :::
 
@@ -297,17 +300,17 @@ taxi_fit %>%
 ::: columns
 ::: {.column width="50%"}
 ```{r augment-acc-3}
-taxi_fit %>%
-  augment(taxi_train) %>%
-  accuracy(tip, .pred_class)
+forested_fit %>%
+  augment(forested_train) %>%
+  accuracy(forested, .pred_class)
 ```
 :::
 
 ::: {.column width="50%"}
 ```{r augment-acc-test}
-taxi_fit %>%
-  augment(taxi_test) %>%
-  accuracy(tip, .pred_class)
+forested_fit %>%
+  augment(forested_test) %>%
+  accuracy(forested, .pred_class)
 ```
 :::
 :::
@@ -343,17 +346,17 @@ countdown::countdown(minutes = 5, id = "augment-metrics")
 ::: columns
 ::: {.column width="50%"}
 ```{r brier-class}
-taxi_fit %>%
-  augment(taxi_train) %>%
-  brier_class(tip, .pred_yes)
+forested_fit %>%
+  augment(forested_train) %>%
+  brier_class(forested, .pred_Yes)
 ```
 :::
 
 ::: {.column width="50%"}
 ```{r brier-class-2}
-taxi_fit %>%
-  augment(taxi_test) %>%
-  brier_class(tip, .pred_yes)
+forested_fit %>%
+  augment(forested_test) %>%
+  brier_class(forested, .pred_Yes)
 ```
 :::
 :::
@@ -405,16 +408,16 @@ countdown::countdown(minutes = 3, id = "percent-in-folds")
 ## Cross-validation `r hexes("rsample")`
 
 ```{r vfold-cv}
-vfold_cv(taxi_train) # v = 10 is default
+vfold_cv(forested_train) # v = 10 is default
 ```
 
 ## Cross-validation `r hexes("rsample")`
 
 What is in this?
 
-```{r taxi-splits}
-taxi_folds <- vfold_cv(taxi_train)
-taxi_folds$splits[1:3]
+```{r forested-splits}
+forested_folds <- vfold_cv(forested_train)
+forested_folds$splits[1:3]
 ```
 
 ::: notes
@@ -424,13 +427,13 @@ Talk about a list column, storing non-atomic types in dataframe
 ## Cross-validation `r hexes("rsample")`
 
 ```{r vfold-cv-v}
-vfold_cv(taxi_train, v = 5)
+vfold_cv(forested_train, v = 5)
 ```
 
 ## Cross-validation `r hexes("rsample")`
 
 ```{r vfold-cv-strata}
-vfold_cv(taxi_train, strata = tip)
+vfold_cv(forested_train, strata = forested)
 ```
 
 . . .
@@ -441,10 +444,10 @@ Stratification often helps, with very little downside
 
 We'll use this setup:
 
-```{r taxi-folds}
+```{r forested-folds}
 set.seed(123)
-taxi_folds <- vfold_cv(taxi_train, v = 10, strata = tip)
-taxi_folds
+forested_folds <- vfold_cv(forested_train, v = 10, strata = forested)
+forested_folds
 ```
 
 . . .
@@ -456,14 +459,14 @@ Set the seed when creating resamples
 ## Fit our model to the resamples
 
 ```{r fit-resamples}
-taxi_res <- fit_resamples(taxi_wflow, taxi_folds)
-taxi_res
+forested_res <- fit_resamples(forested_wflow, forested_folds)
+forested_res
 ```
 
 ## Evaluating model performance `r hexes("tune")`
 
 ```{r collect-metrics}
-taxi_res %>%
+forested_res %>%
   collect_metrics()
 ```
 
@@ -481,17 +484,17 @@ How do the metrics from resampling compare to the metrics from training and test
 
 ```{r calc-roc-auc}
 #| echo: false
-taxi_training_roc_auc <-
-  taxi_fit %>%
-  augment(taxi_train) %>%
-  roc_auc(tip, .pred_yes) %>%
+forested_training_roc_auc <-
+  forested_fit %>%
+  augment(forested_train) %>%
+  roc_auc(forested, .pred_Yes) %>%
   pull(.estimate) %>%
   round(digits = 2)
 
-taxi_testing_roc_auc <-
-  taxi_fit %>%
-  augment(taxi_test) %>%
-  roc_auc(tip, .pred_yes) %>%
+forested_testing_roc_auc <-
+  forested_fit %>%
+  augment(forested_test) %>%
+  roc_auc(forested, .pred_Yes) %>%
   pull(.estimate) %>%
   round(digits = 2)
 ```
@@ -499,7 +502,7 @@ taxi_testing_roc_auc <-
 ::: columns
 ::: {.column width="50%"}
 ```{r collect-metrics-2}
-taxi_res %>%
+forested_res %>%
   collect_metrics() %>% 
   select(.metric, mean, n)
 ```
@@ -508,8 +511,8 @@ taxi_res %>%
 ::: {.column width="50%"}
 The ROC AUC previously was
 
-- `r taxi_training_roc_auc` for the training set
-- `r taxi_testing_roc_auc` for test set
+- `r forested_training_roc_auc` for the training set
+- `r forested_testing_roc_auc` for test set
 :::
 :::
 
@@ -525,32 +528,32 @@ Remember that:
 
 ```{r save-predictions}
 # Save the assessment set results
-ctrl_taxi <- control_resamples(save_pred = TRUE)
-taxi_res <- fit_resamples(taxi_wflow, taxi_folds, control = ctrl_taxi)
+ctrl_forested <- control_resamples(save_pred = TRUE)
+forested_res <- fit_resamples(forested_wflow, forested_folds, control = ctrl_forested)
 
-taxi_res
+forested_res
 ```
 
 ## Evaluating model performance `r hexes("tune")`
 
 ```{r collect-predictions}
 # Save the assessment set results
-taxi_preds <- collect_predictions(taxi_res)
-taxi_preds
+forested_preds <- collect_predictions(forested_res)
+forested_preds
 ```
 
 ## Evaluating model performance `r hexes("tune")`
 
-```{r taxi-metrics-by-id}
-taxi_preds %>% 
+```{r forested-metrics-by-id}
+forested_preds %>% 
   group_by(id) %>%
-  taxi_metrics(truth = tip, estimate = .pred_class)
+  forested_metrics(truth = forested, estimate = .pred_class)
 ```
 
 ## Where are the fitted models? `r hexes("tune")`  {.annotation}
 
-```{r taxi-res}
-taxi_res
+```{r forested-res}
+forested_res
 ```
 
 . . .
@@ -567,7 +570,7 @@ taxi_res
 
 ```{r bootstraps}
 set.seed(3214)
-bootstraps(taxi_train)
+bootstraps(forested_train)
 ```
 
 ##  {background-iframe="https://rsample.tidymodels.org/reference/index.html"}
@@ -605,15 +608,15 @@ countdown::countdown(minutes = 5, id = "try-rsample")
 
 ```{r mc-cv}
 set.seed(322)
-mc_cv(taxi_train, times = 10)
+mc_cv(forested_train, times = 10)
 ```
 
 ## Validation set `r hexes("rsample")`
 
 ```{r validation-split}
 set.seed(853)
-taxi_val_split <- initial_validation_split(taxi, strata = tip)
-validation_set(taxi_val_split)
+forested_val_split <- initial_validation_split(forested, strata = forested)
+validation_set(forested_val_split)
 ```
 
 . . .
@@ -646,7 +649,7 @@ rf_spec
 ## Create a random forest model `r hexes("workflows")`
 
 ```{r rf-wflow}
-rf_wflow <- workflow(tip ~ ., rf_spec)
+rf_wflow <- workflow(forested ~ ., rf_spec)
 rf_wflow
 ```
 
@@ -667,12 +670,12 @@ countdown::countdown(minutes = 8, id = "try-fit-resamples")
 ## Evaluating model performance `r hexes("tune")`
 
 ```{r collect-metrics-rf}
-ctrl_taxi <- control_resamples(save_pred = TRUE)
+ctrl_forested <- control_resamples(save_pred = TRUE)
 
 # Random forest uses random numbers so set the seed first
 
 set.seed(2)
-rf_res <- fit_resamples(rf_wflow, taxi_folds, control = ctrl_taxi)
+rf_res <- fit_resamples(rf_wflow, forested_folds, control = ctrl_forested)
 collect_metrics(rf_res)
 ```
 
@@ -695,8 +698,8 @@ Let's fit the model on the training set and verify our performance using the tes
 We've shown you `fit()` and `predict()` (+ `augment()`) but there is a shortcut:
 
 ```{r final-fit}
-# taxi_split has train + test info
-final_fit <- last_fit(rf_wflow, taxi_split) 
+# forested_split has train + test info
+final_fit <- last_fit(rf_wflow, forested_split) 
 
 final_fit
 ```

--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -79,17 +79,9 @@ augment(forested_fit, new_data = forested_train) %>%
 :::
 :::
 
-## Dangers of accuracy `r hexes("yardstick")`
-
-We need to be careful of using `accuracy()` since it can give "good" performance by only predicting one way with imbalanced data
-
-```{r acc-2}
-augment(forested_fit, new_data = forested_train) %>%
-  mutate(.pred_class = factor("Yes", levels = c("Yes", "No"))) %>%
-  accuracy(truth = forested, estimate = .pred_class)
-```
-
-<!-- TODO: do we need to adjust this now that classes are relatively balanced? -->
+::: notes
+There used to be a slide here calling out the pitfalls of accuracy when classes are imbalanced.
+:::
 
 ## Metrics for model performance `r hexes("yardstick")`
 

--- a/slides/intro-05-tuning-models.qmd
+++ b/slides/intro-05-tuning-models.qmd
@@ -27,14 +27,15 @@ knitr:
 ```{r setup-previous}
 #| echo: false
 library(tidymodels)
+library(forested)
 
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 
 set.seed(123)
-taxi_folds <- vfold_cv(taxi_train, v = 10, strata = tip)
+forested_folds <- vfold_cv(forested_train, v = 10, strata = forested)
 ```
 
 ## Tuning parameters
@@ -81,7 +82,7 @@ Let's take our previous random forest workflow and tag for tuning the minimum nu
 rf_spec <- rand_forest(min_n = tune()) %>% 
   set_mode("classification")
 
-rf_wflow <- workflow(tip ~ ., rf_spec)
+rf_wflow <- workflow(forested ~ ., rf_spec)
 rf_wflow
 ```
 
@@ -96,7 +97,7 @@ rf_wflow
 set.seed(22)
 rf_res <- tune_grid(
   rf_wflow,
-  taxi_folds,
+  forested_folds,
   grid = 5
 )
 ```
@@ -123,7 +124,7 @@ best_parameter
 
 rf_wflow <- finalize_workflow(rf_wflow, best_parameter)
 
-final_fit <- last_fit(rf_wflow, taxi_split) 
+final_fit <- last_fit(rf_wflow, forested_split) 
 
 collect_metrics(final_fit)
 ```

--- a/slides/intro-extra-recipes.qmd
+++ b/slides/intro-extra-recipes.qmd
@@ -30,15 +30,16 @@ knitr:
 #| label: setup-previous
 #| echo: false
 library(tidymodels)
+library(forested)
 
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 
 tree_spec <- decision_tree(cost_complexity = 0.0001, mode = "classification")
-taxi_wflow <- workflow(tip ~ ., tree_spec)
-taxi_fit <- fit(taxi_wflow, taxi_train)
+forested_wflow <- workflow(forested ~ ., tree_spec)
+forested_fit <- fit(forested_wflow, forested_train)
 ```
 
 ```{r}
@@ -50,8 +51,8 @@ ggplot2::theme_set(ggplot2::theme_bw())
 ```
 
 ```{r}
-#| label: taxi_train
-taxi_train
+#| label: forested_train
+forested_train
 ```
 
 ## Working with other models
@@ -174,22 +175,22 @@ Trained methods need to calculate **sufficient information** to be applied again
 ## How to write a recipe
 
 :::{style="font-family: 'Source Code Pro', monospace; font-size: 0.8em;"}
-taxi_rec <- recipe(tip ~ ., data = taxi_train) %>%  
+forested_rec <- recipe(forested ~ ., data = forested_train) %>%  
 \ \ step_unknown(all_nominal_predictors()) %>%  
 \ \ step_dummy(all_nominal_predictors()) %>%  
 \ \ step_zv(all_predictors()) %>%  
-\ \ step_log(distance, offset = 0.5) %>%  
+\ \ step_log(canopy_cover, offset = 0.5) %>%  
 \ \ step_normalize(all_numeric_predictors())
 :::
 
 ## How to write a recipe
 
 :::{style="font-family: 'Source Code Pro', monospace; font-size: 0.8em;"}
-taxi_rec <- [recipe(tip ~ ., data = taxi_train)]{style="color: #CA225E;"} %>%  
+forested_rec <- [recipe(forested ~ ., data = forested_train)]{style="color: #CA225E;"} %>%  
 \ \ step_unknown(all_nominal_predictors()) %>%  
 \ \ step_dummy(all_nominal_predictors()) %>%  
 \ \ step_zv(all_predictors()) %>%  
-\ \ step_log(distance, offset = 0.5) %>%  
+\ \ step_log(canopy_cover, offset = 0.5) %>%  
 \ \ step_normalize(all_numeric_predictors())
 :::
 
@@ -200,11 +201,11 @@ Start by calling `recipe()` to denote the data source and variables used.
 ## How to write a recipe
 
 :::{style="font-family: 'Source Code Pro', monospace; font-size: 0.8em;"}
-taxi_rec <- recipe(tip ~ ., data = taxi_train) %>%  
+forested_rec <- recipe(forested ~ ., data = forested_train) %>%  
 \ \ [step_unknown]{style="color: #CA225E;"}(all_nominal_predictors()) %>%  
 \ \ [step_dummy]{style="color: #CA225E;"}(all_nominal_predictors()) %>%  
 \ \ [step_zv]{style="color: #CA225E;"}(all_predictors()) %>%  
-\ \ [step_log]{style="color: #CA225E;"}(distance, offset = 0.5) %>%  
+\ \ [step_log]{style="color: #CA225E;"}(canopy_cover, offset = 0.5) %>%  
 \ \ [step_normalize]{style="color: #CA225E;"}(all_numeric_predictors())
 :::
 
@@ -215,11 +216,11 @@ Specify what actions to take by adding `step_*()`s.
 ## How to write a recipe
 
 :::{style="font-family: 'Source Code Pro', monospace; font-size: 0.8em;"}
-taxi_rec <- recipe(tip ~ ., data = taxi_train) %>%  
+forested_rec <- recipe(forested ~ ., data = forested_train) %>%  
 \ \ step_unknown([all_nominal_predictors()]{style="color: #CA225E;"}) %>%  
 \ \ step_dummy([all_nominal_predictors()]{style="color: #CA225E;"}) %>%  
 \ \ step_zv([all_predictors()]{style="color: #CA225E;"}) %>%  
-\ \ step_log([distance]{style="color: #CA225E;"}, offset = 0.5) %>% 
+\ \ step_log([canopy_cover]{style="color: #CA225E;"}, offset = 0.5) %>% 
 \ \ step_normalize([all_numeric_predictors()]{style="color: #CA225E;"})
 :::
 <br>
@@ -229,11 +230,11 @@ Use {tidyselect} and recipes-specific selectors to denote affected variables.
 ## Using a recipe
 
 :::{style="font-family: 'Source Code Pro', monospace; font-size: 0.8em;"}
-taxi_rec <- recipe(tip ~ ., data = taxi_train) %>%  
+forested_rec <- recipe(forested ~ ., data = forested_train) %>%  
 \ \ step_unknown(all_nominal_predictors()) %>%  
 \ \ step_dummy(all_nominal_predictors()) %>%  
 \ \ step_zv(all_predictors()) %>%  
-\ \ step_log(distance, offset = 0.5) %>% 
+\ \ step_log(canopy_cover, offset = 0.5) %>% 
 \ \ step_normalize(all_numeric_predictors())
 :::
 
@@ -250,8 +251,8 @@ Recipes are typically combined with a model in a `workflow()` object:
 <br>
 
 :::{style="font-family: 'Source Code Pro', monospace; font-size: 0.8em;"}
-taxi_wflow <- workflow() %>%  
-\ \ [add_recipe(taxi_rec)]{style="color: #CA225E;"} %>%  
+forested_wflow <- workflow() %>%  
+\ \ [add_recipe(forested_rec)]{style="color: #CA225E;"} %>%  
 \ \ add_model(linear_reg())
 :::
 
@@ -273,7 +274,7 @@ Once a recipe is added to a workflow, this occurs when `fit()` is called.
 
 . . .
 
-- If you have an error and need to debug your recipe, the original recipe object (e.g. `taxi_rec`) can be estimated manually with a function called `prep()`. It is analogous to `fit()`. See [TMwR section 16.4](https://www.tmwr.org/dimensionality.html#recipe-functions).
+- If you have an error and need to debug your recipe, the original recipe object (e.g. `forested_rec`) can be estimated manually with a function called `prep()`. It is analogous to `fit()`. See [TMwR section 16.4](https://www.tmwr.org/dimensionality.html#recipe-functions).
 
 . . .
 
@@ -300,36 +301,36 @@ countdown::countdown(minutes = 5, id = "recipes-prep")
 ## Printing a recipe
 
 ```{r}
-#| label: taxi_rec
+#| label: forested_rec
 #| echo: false
-taxi_rec <- recipe(tip ~ ., data = taxi_train) %>%  
+forested_rec <- recipe(forested ~ ., data = forested_train) %>%  
   step_unknown(all_nominal_predictors()) %>%  
   step_dummy(all_nominal_predictors()) %>%  
   step_zv(all_predictors()) %>%  
-  step_log(distance, offset = 0.5) %>% 
+  step_log(canopy_cover, offset = 0.5) %>% 
   step_normalize(all_numeric_predictors())
 ```
 
 ```{r}
-#| label: taxi_rec-printing
+#| label: forested_rec-printing
 #| message: true
-taxi_rec
+forested_rec
 ```
 
 ## Prepping a recipe
 
 ```{r}
-#| label: taxi_rec-prep-printing
+#| label: forested_rec-prep-printing
 #| message: true
-prep(taxi_rec)
+prep(forested_rec)
 ```
 
 ## Baking a recipe
 
 ```{r}
-#| label: taxi_rec-prep-bake-printing
-prep(taxi_rec) %>%
-  bake(new_data = taxi_train)
+#| label: forested_rec-prep-bake-printing
+prep(forested_rec) %>%
+  bake(new_data = forested_train)
 ```
 
 ## Tidying a recipe
@@ -357,16 +358,16 @@ countdown::countdown(minutes = 5, id = "recipes-tidy")
 ## Tidying a recipe
 
 ```{r}
-#| label: taxi_rec-tidy
-prep(taxi_rec) %>%
+#| label: forested_rec-tidy
+prep(forested_rec) %>%
   tidy()
 ```
 
 ## Tidying a recipe
 
 ```{r}
-#| label: taxi_rec-tidy-2
-prep(taxi_rec) %>%
+#| label: forested_rec-tidy-2
+prep(forested_rec) %>%
   tidy(number = 2)
 ```
 
@@ -377,8 +378,8 @@ The recommended way to use a recipe in tidymodels is to use it as part of a `wor
 
 ```{r}
 #| label: recipes-and-workflows
-taxi_wflow <- workflow() %>%  
-  add_recipe(taxi_rec) %>%  
+forested_wflow <- workflow() %>%  
+  add_recipe(forested_rec) %>%  
   add_model(linear_reg())
 ```
 

--- a/slides/intro-extra-workflowsets.qmd
+++ b/slides/intro-extra-workflowsets.qmd
@@ -47,7 +47,7 @@ rf_spec <- rand_forest(trees = 1000, mode = "classification")
 
 ## How can we compare multiple model workflows at once?
 
-```{r forested-spinning, echo = FALSE}
+```{r taxi-spinning, echo = FALSE}
 #| fig-align: "center"
 
 knitr::include_graphics("images/taxi_spinning.svg")

--- a/slides/intro-extra-workflowsets.qmd
+++ b/slides/intro-extra-workflowsets.qmd
@@ -27,18 +27,19 @@ knitr:
 ```{r setup-previous}
 #| echo: false
 library(tidymodels)
+library(forested)
 
 set.seed(123)
-taxi_split <- initial_split(taxi, prop = 0.8, strata = tip)
-taxi_train <- training(taxi_split)
-taxi_test <- testing(taxi_split)
+forested_split <- initial_split(forested, prop = 0.8, strata = forested)
+forested_train <- training(forested_split)
+forested_test <- testing(forested_split)
 
 set.seed(123)
-taxi_folds <- vfold_cv(taxi_train, v = 10, strata = tip)
+forested_folds <- vfold_cv(forested_train, v = 10, strata = forested)
 
-tree_spec <- decision_tree(cost_complexity = 0.0001, mode = "classification")
-taxi_wflow <- workflow(tip ~ ., tree_spec)
-taxi_fit <- fit(taxi_wflow, taxi_train)
+tree_spec <- decision_tree(mode = "classification")
+forested_wflow <- workflow(forested ~ ., tree_spec)
+forested_fit <- fit(forested_wflow, forested_train)
 
 rf_spec <- rand_forest(trees = 1000, mode = "classification")
 ```
@@ -46,7 +47,7 @@ rf_spec <- rand_forest(trees = 1000, mode = "classification")
 
 ## How can we compare multiple model workflows at once?
 
-```{r taxi-spinning, echo = FALSE}
+```{r forested-spinning, echo = FALSE}
 #| fig-align: "center"
 
 knitr::include_graphics("images/taxi_spinning.svg")
@@ -55,21 +56,21 @@ knitr::include_graphics("images/taxi_spinning.svg")
 ## Evaluate a workflow set
 
 ```{r workflow-set}
-workflow_set(list(tip ~ .), list(tree_spec, rf_spec))
+workflow_set(list(forested ~ .), list(tree_spec, rf_spec))
 ```
 
 ## Evaluate a workflow set
 
 ```{r workflow-map}
-workflow_set(list(tip ~ .), list(tree_spec, rf_spec)) %>%
-  workflow_map("fit_resamples", resamples = taxi_folds)
+workflow_set(list(forested ~ .), list(tree_spec, rf_spec)) %>%
+  workflow_map("fit_resamples", resamples = forested_folds)
 ```
 
 ## Evaluate a workflow set
 
 ```{r rank-results}
-workflow_set(list(tip ~ .), list(tree_spec, rf_spec)) %>%
-  workflow_map("fit_resamples", resamples = taxi_folds) %>%
+workflow_set(list(forested ~ .), list(tree_spec, rf_spec)) %>%
+  workflow_map("fit_resamples", resamples = forested_folds) %>%
   rank_results()
 ```
 


### PR DESCRIPTION
A first pass at transitioning from the taxi data to [forested](https://github.com/simonpcouch/forested). 

Tried to mostly stick to finding + replacing for this first PR, dropping `TODO`s where our previous discussion / interpretation needs some reworking. Process was: add `library(forested)` in setup, search for `tip` to make sure there weren't bad substitutions (like "multiple") and then replace with `forested`, replace `taxi` with `forested`.

For the most part, metrics tend to improve in the same situations when they did for the taxi data, so that will save us larger refactorings. That said:

* The outcome classes are much more balanced in this problem, so the `accuracy()` discussion might need some reworking.
* We no longer need to set `cost_complexity` to get a reasonably teachable tree back. I _think_ we intentionally set `cost_complexity` to a lower value when we're not plotting the trees (i.e. after deck 3) to get more solid performance. The previous `cost_complexity = 0.0001` returns a reasonable tree in that case. With that in mind, maybe we should set `cost_complexity` to its default value explicitly so that unexpectedly seeing `cost_complexity` doesn't confuse people.
* The time-based split extra will need a proper rewrite, which I've left for another PR.
* The recipes extra deserves a good bit more attention as well.

We also still have:

``` r
files <- list.files(recursive = TRUE)
files <- files[!grepl("archive|docs", files)]
grep("taxi", files, value = TRUE)
#> [1] "slides/images/taxi_spinning.svg" "slides/images/taxi.png"         
#> [3] "slides/taxi_raw.R"               "slides/taxi_raw.rds"
```

(`taxi_raw` is for the time-based split content.)

Obviously lots more to do, but should be a good place to jump off from / create issues based off of. :) I'm able to `quarto::render()` without issue.