### PR TITLE
shoutout TA in slides

### DIFF
--- a/slides/intro-01-introduction.qmd
+++ b/slides/intro-01-introduction.qmd
@@ -79,6 +79,10 @@ Wi-Fi password
 
 . . .
 
+\+ our TA today, Sara Altman!
+
+. . .
+
 Many thanks to Davis Vaughan, Julia Silge, David Robinson, Julie Jung, Alison Hill, and Desirée De Leon for their role in creating these materials!
 
 ## Asking for help {visibility="hidden"}


### PR DESCRIPTION
closes #315 

With these changes, slide is (eventually) full but not running off the page:

![Screenshot 2024-07-23 at 12 49 37 PM](https://github.com/user-attachments/assets/78d1a1bc-6cc8-488c-abf6-ef8cedf65787)
