### PR TITLE
Update list of possible linear models

### DIFF
--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -40,8 +40,6 @@ countdown::countdown(minutes = 3, id = "how-to-fit-linear-model")
 
 -   `lm` for linear model
 
--   `glm` for generalized linear model (e.g. logistic regression)
-
 -   `glmnet` for regularized regression
 
 -   `keras` for regression using TensorFlow
@@ -49,6 +47,8 @@ countdown::countdown(minutes = 3, id = "how-to-fit-linear-model")
 -   `stan` for Bayesian regression
 
 -   `spark` for large data sets
+
+-   `brulee` for regression using torch
 
 ## To specify a model `r hexes("parsnip")`
 


### PR DESCRIPTION
closes #303 and closes #294 

So this slide is already pretty full, we essentially have room for one more line. 

Adding the detail about the link function to `glm` makes it spill into an additional line. Adding `brulee` obviously also take a line. So I've opted here for removing `glm` to make room for `brulee`. 

We won't be able to achieve completeness in one slide anyway, our [list of available engines](https://parsnip.tidymodels.org/reference/linear_reg.html) is now way too long! 🎉 