### PR TITLE
sync discussion of metric group-awareness

### DIFF
--- a/classwork/intro-04-classwork.qmd
+++ b/classwork/intro-04-classwork.qmd
@@ -51,20 +51,20 @@ augment(forested_fit, new_data = forested_train) %>%
   accuracy(truth = forested, estimate = .pred_class)
 ```
 
-All yardstick metric functions work with grouped data frames!
-
-```{r}
-augment(forested_fit, new_data = forested_train) %>%
-  group_by(tree_no_tree) %>%
-  accuracy(truth = forested, estimate = .pred_class)
-```
-
 Metric sets are a way to combine multiple similar metric functions together into a new function.
 
 ```{r}
 forested_metrics <- metric_set(accuracy, specificity, sensitivity)
 
 augment(forested_fit, new_data = forested_train) %>%
+  forested_metrics(truth = forested, estimate = .pred_class)
+```
+
+Metrics and metric sets work with grouped data frames!
+
+```{r}
+augment(forested_fit, new_data = forested_train) %>%
+  group_by(tree_no_tree) %>%
   forested_metrics(truth = forested, estimate = .pred_class)
 ```
 

--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -134,6 +134,8 @@ augment(forested_fit, new_data = forested_train) %>%
 
 ## Metrics for model performance `r hexes("yardstick")`
 
+Metrics and metric sets work with grouped data frames!
+
 ```{r forested-metrics-grouped}
 forested_metrics <- metric_set(accuracy, specificity, sensitivity)
 


### PR DESCRIPTION
Closes #309.

The diff is a bit strange for the classwork, but I just bumped the group-awareness chunk one below and changed the verbiage to match the slides.

Not suuuuper stoked about where this fits in but I'm not sure there's a better place and I do think we should teach this. There's a nice disparity in specificity between `Tree` / `No tree` as well which is a nice talking point.

