### PR TITLE
rephrase exercise on `predict()` + `augment()` output format

### DIFF
--- a/classwork/intro-03-classwork.qmd
+++ b/classwork/intro-03-classwork.qmd
@@ -118,19 +118,23 @@ tree_fit <-
 
 ## Your turn
 
-What do you get from running the following code? What do you notice about the structure of the result?
+Run:
 
 ```{r}
 predict(tree_fit, new_data = forested_test)
 ```
 
+What do you notice about the structure of the result?
+
 ## Your turn
 
-What do you get from running the following code? How is `augment()` different from `predict()`?
+Run:
 
 ```{r}
 augment(tree_fit, new_data = forested_test)
 ```
+
+How does the output compare to the output from `predict()`?
 
 ## Understand your model
 

--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -541,7 +541,7 @@ tree_fit <-
 
 `predict(tree_fit, new_data = forested_test)`
 
-*What do you get?*
+*What do you notice about the structure of the result?*
 
 ```{r ex-predict-tree-fit}
 #| echo: false
@@ -556,7 +556,7 @@ countdown::countdown(minutes = 3, id = "predict-tree-fit")
 
 `augment(tree_fit, new_data = forested_test)`
 
-*What do you get?*
+*How does the output compare to the output from `predict()`?*
 
 ```{r ex-augment-tree-fit}
 #| echo: false


### PR DESCRIPTION
Closes #161.

Syncs the slides and classword and rephrases the exercises on the output format of `predict()` + `augment()` to elicit the [prediction guarantee](https://tidymodels.github.io/model-implementation-principles/model-predictions.html) a bit more directly.