### PR TITLE
Update section name for grid search annotations

### DIFF
--- a/slides/annotations.qmd
+++ b/slides/annotations.qmd
@@ -139,7 +139,7 @@ For more advanced use cases, you can extract and save them. See:
 
 <hr size="5">
 
-# 06 - Tuning Hyperparameters
+# 03 - Tuning Hyperparameters
 
 ## Different types of grids
 


### PR DESCRIPTION
closes  #302

I'm assuming that the main grid search tuning deck should be deck `3`, see https://github.com/tidymodels/workshops/issues/348