### PR TITLE
correct row count of `forested`

### DIFF
--- a/slides/intro-02-data-budget.qmd
+++ b/slides/intro-02-data-budget.qmd
@@ -50,7 +50,7 @@ Credit: <https://www.svgrepo.com/svg/251793/forest-mountain>
 
 ::: columns
 ::: {.column width="70%"}
--   `N = 7,109` plots of land, one from each of 7,109 6000-acre hexagons in WA.
+-   `N = 7,107` plots of land, one from each of 7,107 6000-acre hexagons in WA.
 -   A nominal outcome, `forested`, with levels `"Yes"` and `"No"`, measured "on-the-ground."
 -   18 remotely-sensed and easily-accessible predictors:
      - **numeric** variables based on weather and topography.


### PR DESCRIPTION
The row count dropped by 2 when we re-rendered `forested` using the rasters that were "clipped" to Washington rather than the national ones since 2 plots were centered close enough to the border to have non-Washington data--forgot to update that row count here.