### PR TITLE
update packages lists

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -41,7 +41,7 @@ The process to set up your computer for either workshop will look the same. Plea
 
 -   A recent version of R, available at <https://cran.r-project.org/>
 -   A recent version of RStudio Desktop (RStudio Desktop Open Source License, at least v2024.04.0), available at <https://posit.co/download/rstudio-desktop/>
--   The following R packages, which you can install from the R console:
+-   For _all of the slides_, the following R packages can be installed from the R console:
 
 ```{r}
 #| label: installs
@@ -50,10 +50,10 @@ The process to set up your computer for either workshop will look the same. Plea
 
 # Install the packages for the workshop
 pkgs <- 
-  c("bonsai", "doParallel", "embed", "finetune", "forested", "lightgbm", "lme4",
-    "plumber", "probably", "ranger", "rpart", "rpart.plot", "rules",
-    "splines2", "stacks", "text2vec", "textrecipes", "tidymodels", 
-    "vetiver")
+  c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
+    "forested", "lightgbm", "lme4", "plumber", "probably", "ranger", 
+    "rpart", "rpart.plot", "rules", "splines2", "stacks", "text2vec", 
+    "textrecipes", "tidymodels", "vetiver")
 
 install.packages(pkgs)
 ```

--- a/index.qmd
+++ b/index.qmd
@@ -51,9 +51,9 @@ The process to set up your computer for either workshop will look the same. Plea
 # Install the packages for the workshop
 pkgs <- 
   c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
-    "forested", "lightgbm", "lme4", "plumber", "probably", "ranger", 
-    "rpart", "rpart.plot", "rules", "splines2", "stacks", "text2vec", 
-    "textrecipes", "tidymodels", "vetiver")
+    "forested", "lightgbm", "lme4", "parallelly", "plumber", "probably", 
+    "ranger", "rpart", "rpart.plot", "rules", "splines2", "stacks", 
+    "text2vec", "textrecipes", "tidymodels", "vetiver")
 
 install.packages(pkgs)
 ```

--- a/slides/advanced-01-introduction.qmd
+++ b/slides/advanced-01-introduction.qmd
@@ -141,15 +141,17 @@ Many thanks to Davis Vaughan, Julia Silge, David Robinson, Julie Jung, Alison Hi
 
 ## Let's install some packages
 
-If you are using your own laptop instead of RStudio Cloud:
+If you are using your own laptop instead of Posit Cloud:
 
 ```{r load-pkgs}
 #| eval: false
 
-# Install the packages for the advanced slides
-pkgs <- c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
-          "lightgbm", "lme4", "plumber", "probably", "rules", "splines2", 
-           "stacks", "text2vec", "textrecipes", "tidymodels", "vetiver")
+# Install the packages for the workshop
+pkgs <- 
+  c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
+    "forested", "lightgbm", "lme4", "parallelly", "plumber", "probably", 
+    "ranger", "rpart", "rpart.plot", "rules", "splines2", "stacks", 
+    "text2vec", "textrecipes", "tidymodels", "vetiver")
 
 install.packages(pkgs)
 ```

--- a/slides/advanced-01-introduction.qmd
+++ b/slides/advanced-01-introduction.qmd
@@ -146,19 +146,22 @@ If you are using your own laptop instead of RStudio Cloud:
 ```{r load-pkgs}
 #| eval: false
 
-# Install the packages for the workshop
-pkgs <- 
-  c("bonsai", "doParallel", "embed", "finetune", "forested", "lightgbm", "lme4",
-    "plumber", "probably", "ranger", "rpart", "rpart.plot", "rules",
-    "splines2", "stacks", "text2vec", "textrecipes", "tidymodels", 
-    "vetiver")
+# Install the packages for the advanced slides
+pkgs <- c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
+          "lightgbm", "lme4", "plumber", "probably", "rules", "splines2", 
+           "stacks", "text2vec", "textrecipes", "tidymodels", "vetiver")
 
 install.packages(pkgs)
 ```
 
-. . .
+Also, you should install the newest version of the dials package (version 1.3.0). To check this, you can run: 
 
-<br></br>
+```{r}
+#| label: check-dials
+#| eval: false
+#| echo: true
+rlang::check_installed("dials", version = "1.3.0")
+```
 
 ## Hotel Data `r hexes("tidymodels", "dplyr")`
 

--- a/slides/advanced-01-introduction.qmd
+++ b/slides/advanced-01-introduction.qmd
@@ -263,10 +263,9 @@ countdown::countdown(minutes = 10, id = "hotel-investigation")
 
 ```{r pkg-list, echo = FALSE}
 deps <- 
-  c("bonsai", "doParallel", "embed", "finetune", "forested", "lightgbm", "lme4",
-    "plumber", "probably", "ranger", "rpart", "rpart.plot", "rules",
-    "splines2", "stacks", "text2vec", "textrecipes", "tidymodels", 
-    "vetiver")
+  c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
+    "lightgbm", "lme4", "plumber", "probably", "rules", "splines2", 
+    "stacks", "text2vec", "textrecipes", "tidymodels", "vetiver")
 
 loaded <- purrr::map(deps, ~ library(.x, character.only = TRUE))
 excl <- c("iterators", "emo", "countdown", "stats", "graphics", 

--- a/slides/intro-01-introduction.qmd
+++ b/slides/intro-01-introduction.qmd
@@ -282,9 +282,9 @@ If you are using your own laptop instead of Posit Cloud:
 # Install the packages for the workshop
 pkgs <- 
   c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
-    "forested", "lightgbm", "lme4", "plumber", "probably", "ranger", 
-    "rpart", "rpart.plot", "rules", "splines2", "stacks", "text2vec", 
-    "textrecipes", "tidymodels", "vetiver")
+    "forested", "lightgbm", "lme4", "parallelly", "plumber", "probably", 
+    "ranger", "rpart", "rpart.plot", "rules", "splines2", "stacks", 
+    "text2vec", "textrecipes", "tidymodels", "vetiver")
 
 install.packages(pkgs)
 ```

--- a/slides/intro-01-introduction.qmd
+++ b/slides/intro-01-introduction.qmd
@@ -281,10 +281,10 @@ If you are using your own laptop instead of Posit Cloud:
 
 # Install the packages for the workshop
 pkgs <- 
-  c("bonsai", "doParallel", "embed", "finetune", "forested", "lightgbm", "lme4",
-    "plumber", "probably", "ranger", "rpart", "rpart.plot", "rules",
-    "splines2", "stacks", "text2vec", "textrecipes", "tidymodels", 
-    "vetiver")
+  c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
+    "forested", "lightgbm", "lme4", "plumber", "probably", "ranger", 
+    "rpart", "rpart.plot", "rules", "splines2", "stacks", "text2vec", 
+    "textrecipes", "tidymodels", "vetiver")
 
 install.packages(pkgs)
 ```
@@ -297,10 +297,10 @@ install.packages(pkgs)
 
 ```{r pkg-list, echo = FALSE}
 deps <- 
-  c("bonsai", "doParallel", "embed", "finetune", "forested", "lightgbm", "lme4",
-    "plumber", "probably", "ranger", "rpart", "rpart.plot", "rules",
-    "splines2", "stacks", "text2vec", "textrecipes", "tidymodels", 
-    "vetiver")
+  c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
+    "forested", "lightgbm", "lme4", "plumber", "probably", "ranger", 
+    "rpart", "rpart.plot", "rules", "splines2", "stacks", "text2vec", 
+    "textrecipes", "tidymodels", "vetiver")
 
 loaded <- purrr::map(deps, ~ library(.x, character.only = TRUE))
 excl <- c("iterators", "emo", "countdown", "stats", "graphics", 


### PR DESCRIPTION
For the main site, we should list all of the package requirements (for both sessions). There were a few from the advanced extras that needed to be included. 

For each of the two intro decks, this PR updates the specific packages needed for the session (e.g., intro vs advances). 

@hfrick @simonpcouch Can you update/trim what you need in the intro slide "Let's install some packages"?