### PR TITLE
include parallely in "our versions"

### DIFF
--- a/slides/advanced-01-introduction.qmd
+++ b/slides/advanced-01-introduction.qmd
@@ -266,7 +266,7 @@ countdown::countdown(minutes = 10, id = "hotel-investigation")
 ```{r pkg-list, echo = FALSE}
 deps <- 
   c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
-    "lightgbm", "lme4", "plumber", "probably", "rules", "splines2", 
+    "lightgbm", "lme4", "parallelly", "plumber", "probably", "rules", "splines2", 
     "stacks", "text2vec", "textrecipes", "tidymodels", "vetiver")
 
 loaded <- purrr::map(deps, ~ library(.x, character.only = TRUE))

--- a/slides/intro-01-introduction.qmd
+++ b/slides/intro-01-introduction.qmd
@@ -298,7 +298,7 @@ install.packages(pkgs)
 ```{r pkg-list, echo = FALSE}
 deps <- 
   c("bonsai", "Cubist", "doParallel", "earth", "embed", "finetune", 
-    "forested", "lightgbm", "lme4", "plumber", "probably", "ranger", 
+    "forested", "lightgbm", "lme4", "parallelly", "plumber", "probably", "ranger", 
     "rpart", "rpart.plot", "rules", "splines2", "stacks", "text2vec", 
     "textrecipes", "tidymodels", "vetiver")
 


### PR DESCRIPTION
Follow-up to #357:

The packages to be installed should also show up on the slide "Our versions". 

This is just the quick fix, improving this for the future is captured in #364 .