### PR TITLE
remove reference to Advanced workshop

### DIFF
--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -704,7 +704,7 @@ A validation set is just another type of resample
 
 . . .
 
-- Often works well without tuning hyperparameters (more on this in Advanced tidymodels!), as long as there are enough trees
+- Often works well without tuning hyperparameters (more on this later!), as long as there are enough trees
 
 ## Create a random forest model `r hexes("parsnip")`
 


### PR DESCRIPTION
"More on this in Advanced tidymodels!" is a bit of a bummer with the 1-day workshop structure. Since we're gonna be talking about tuning in slide deck 5 now, anyway, let's just refer to then. :)