### PR TITLE
inline source code for overfitting plots

### DIFF
--- a/slides/figures/overfitting-test-1.svg
+++ b/slides/figures/overfitting-test-1.svg
@@ -1,0 +1,928 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='720.00pt' height='360.00pt' viewBox='0 0 720.00 360.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='360.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='360.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzEuMzB8MjU1LjM5fDQwLjM2fDMyOC4yNw=='>
+    <rect x='31.30' y='40.36' width='224.09' height='287.90' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzEuMzB8MjU1LjM5fDQwLjM2fDMyOC4yNw==)'>
+<rect x='31.30' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='31.30,279.49 255.39,279.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,208.11 255.39,208.11 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,136.73 255.39,136.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,65.34 255.39,65.34 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='69.27,328.27 69.27,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='124.83,328.27 124.83,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='180.38,328.27 180.38,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='235.94,328.27 235.94,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,315.18 255.39,315.18 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,243.80 255.39,243.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,172.42 255.39,172.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,101.04 255.39,101.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='41.49,328.27 41.49,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='97.05,328.27 97.05,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='152.60,328.27 152.60,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='208.16,328.27 208.16,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<circle cx='213.57' cy='132.89' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='141.71' cy='195.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='134.99' cy='139.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='157.69' cy='163.60' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='154.15' cy='158.49' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='166.42' cy='170.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='170.10' cy='145.90' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='210.80' cy='113.37' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='139.03' cy='198.10' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='179.43' cy='116.31' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='171.51' cy='129.76' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='118.65' cy='187.82' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='133.42' cy='166.72' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='131.20' cy='202.08' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='193.18' cy='163.07' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='154.99' cy='172.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='156.50' cy='157.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='159.45' cy='153.27' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='158.83' cy='177.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='146.93' cy='197.93' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='184.72' cy='142.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='103.74' cy='274.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='144.54' cy='164.85' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='149.55' cy='178.64' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='107.37' cy='203.19' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='155.38' cy='185.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='151.37' cy='108.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='179.56' cy='170.00' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='138.22' cy='156.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='113.88' cy='177.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='161.57' cy='148.83' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='164.54' cy='174.43' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='172.15' cy='180.98' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='134.49' cy='228.13' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='152.08' cy='194.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='151.57' cy='142.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='131.45' cy='207.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='127.09' cy='213.79' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='123.40' cy='226.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.72' cy='221.67' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='170.41' cy='175.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='131.00' cy='168.70' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.02' cy='134.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='122.99' cy='184.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='207.79' cy='108.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='188.95' cy='177.10' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='183.04' cy='195.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='167.15' cy='132.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='142.33' cy='205.16' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='160.88' cy='219.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='145.90' cy='162.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='180.81' cy='178.74' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='170.54' cy='143.97' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='131.73' cy='199.74' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='126.61' cy='187.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='173.64' cy='186.36' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='159.13' cy='150.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='157.60' cy='165.69' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='162.20' cy='122.56' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='147.28' cy='178.13' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='167.70' cy='195.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='189.08' cy='181.24' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='170.48' cy='159.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='174.25' cy='148.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.42' cy='163.51' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='141.12' cy='186.99' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='153.55' cy='186.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='104.10' cy='208.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='140.39' cy='173.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='135.40' cy='193.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='147.46' cy='155.31' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='148.47' cy='220.19' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='152.68' cy='186.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='117.42' cy='213.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='121.00' cy='193.95' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='111.54' cy='232.68' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='169.15' cy='98.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='176.15' cy='163.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='126.59' cy='215.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='191.42' cy='170.94' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='150.53' cy='154.86' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='146.18' cy='161.83' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='179.11' cy='182.77' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='153.51' cy='190.75' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='142.42' cy='156.45' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='123.41' cy='174.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='123.15' cy='181.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='156.03' cy='151.87' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='153.19' cy='204.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='164.35' cy='198.79' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='184.60' cy='128.11' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='123.46' cy='180.55' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='166.19' cy='155.30' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='134.41' cy='201.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='160.45' cy='176.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='178.98' cy='184.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='155.74' cy='167.09' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='162.58' cy='187.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='184.84' cy='116.87' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='170.60' cy='157.06' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='164.67' cy='165.63' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='141.72' cy='163.62' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='131.46' cy='173.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='128.07' cy='169.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='167.33' cy='115.61' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='87.69' cy='230.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='117.74' cy='206.15' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='110.06' cy='225.48' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='121.62' cy='185.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='176.54' cy='150.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='185.02' cy='103.52' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='156.67' cy='186.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='164.71' cy='159.01' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='135.56' cy='239.60' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='226.99' cy='101.90' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='145.99' cy='220.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='135.80' cy='209.85' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='113.77' cy='176.57' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='169.27' cy='111.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='197.91' cy='191.02' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='103.89' cy='264.99' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='169.11' cy='151.53' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='202.53' cy='150.32' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='196.38' cy='96.90' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='151.95' cy='181.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='153.98' cy='197.72' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='153.64' cy='196.52' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='83.17' cy='299.30' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='179.33' cy='105.97' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='128.82' cy='161.03' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='141.99' cy='175.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='126.91' cy='196.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='154.92' cy='212.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='163.56' cy='127.30' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='211.32' cy='95.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='186.74' cy='136.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='188.82' cy='152.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='151.20' cy='171.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='118.78' cy='167.03' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='153.65' cy='177.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='165.88' cy='88.19' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='171.85' cy='189.09' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='176.32' cy='136.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='175.91' cy='213.41' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='185.34' cy='142.57' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='103.98' cy='247.63' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='163.83' cy='195.25' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='173.23' cy='149.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='172.33' cy='148.60' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='154.86' cy='186.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='140.45' cy='189.54' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='128.17' cy='191.13' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='183.78' cy='102.77' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='144.76' cy='153.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='107.26' cy='230.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='136.38' cy='191.79' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='112.58' cy='183.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='153.75' cy='197.50' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='139.54' cy='187.39' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='198.40' cy='140.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='183.40' cy='140.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='144.37' cy='193.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='153.92' cy='187.38' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='190.07' cy='121.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='197.46' cy='139.61' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='127.43' cy='193.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='135.46' cy='197.22' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='134.12' cy='176.94' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='157.68' cy='161.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='157.17' cy='184.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='166.44' cy='183.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='157.95' cy='161.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='163.64' cy='168.84' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='168.89' cy='130.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='152.36' cy='182.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='177.31' cy='125.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='171.83' cy='185.44' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='148.81' cy='145.41' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='125.24' cy='193.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='197.18' cy='145.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='136.24' cy='196.19' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='198.09' cy='100.93' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='137.92' cy='162.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='151.78' cy='151.98' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='140.12' cy='174.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='174.17' cy='127.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='162.05' cy='134.06' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='142.16' cy='170.52' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='184.34' cy='87.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='152.33' cy='137.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='75.48' cy='270.87' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='104.12' cy='214.24' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='136.04' cy='164.42' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='143.92' cy='150.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='105.97' cy='179.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='206.51' cy='116.41' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='154.14' cy='184.15' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='163.54' cy='162.89' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='166.22' cy='176.84' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='157.20' cy='129.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='169.57' cy='161.92' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='58.38' cy='242.27' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='167.57' cy='157.65' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='112.95' cy='245.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='154.27' cy='184.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='195.59' cy='151.71' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='162.05' cy='222.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='209.42' cy='94.68' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='178.49' cy='145.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='152.87' cy='160.92' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='170.72' cy='186.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='156.21' cy='175.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='176.23' cy='173.09' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='156.25' cy='196.38' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='102.25' cy='229.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='153.72' cy='149.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='172.91' cy='165.75' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='119.01' cy='226.24' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='161.81' cy='147.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='152.03' cy='173.95' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='124.89' cy='205.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='141.61' cy='181.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='127.10' cy='226.43' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='136.34' cy='186.31' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='132.43' cy='172.30' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='114.32' cy='190.11' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='208.10' cy='139.51' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='184.75' cy='134.27' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='163.85' cy='162.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='164.96' cy='177.28' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='134.21' cy='247.20' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='143.63' cy='197.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='171.51' cy='189.28' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='180.32' cy='162.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='128.20' cy='162.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='166.16' cy='110.52' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='177.31' cy='145.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='187.67' cy='152.62' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='115.23' cy='217.83' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='109.00' cy='237.79' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='106.78' cy='184.54' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='126.21' cy='179.20' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='147.15' cy='196.45' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='147.28' cy='134.57' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='118.25' cy='197.78' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='178.74' cy='199.07' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='144.95' cy='216.55' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='147.92' cy='152.13' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='188.14' cy='157.19' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='132.04' cy='209.22' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<polyline points='175.59,153.40 174.57,153.27 173.54,153.15 172.52,153.06 171.50,152.97 170.47,152.91 169.45,152.86 168.43,152.82 167.40,152.81 166.38,152.81 165.35,152.83 164.33,152.86 163.31,152.92 162.28,152.99 161.26,153.09 160.24,153.21 159.21,153.36 158.96,153.41 158.19,153.54 157.17,153.75 156.14,153.98 155.12,154.26 154.09,154.57 153.66,154.72 153.07,154.93 152.05,155.34 151.02,155.80 150.56,156.04 150.00,156.33 148.98,156.92 148.32,157.35 147.95,157.60 146.93,158.37 146.58,158.67 145.90,159.26 145.16,159.98 144.88,160.28 143.99,161.30 143.86,161.46 143.00,162.61 142.83,162.86 142.16,163.93 141.81,164.54 141.43,165.24 140.81,166.56 140.79,166.61 140.27,167.87 139.81,169.19 139.76,169.35 139.42,170.50 139.09,171.82 138.80,173.13 138.74,173.50 138.57,174.45 138.39,175.76 138.24,177.08 138.13,178.40 138.06,179.71 138.02,181.03 138.02,182.34 138.05,183.66 138.10,184.97 138.18,186.29 138.30,187.60 138.44,188.92 138.61,190.23 138.74,191.12 138.80,191.55 139.03,192.86 139.29,194.18 139.57,195.49 139.76,196.29 139.89,196.81 140.24,198.12 140.63,199.44 140.79,199.94 141.06,200.75 141.52,202.07 141.81,202.82 142.04,203.38 142.60,204.70 142.83,205.22 143.22,206.02 143.86,207.25 143.90,207.33 144.67,208.65 144.88,209.00 145.52,209.96 145.90,210.51 146.49,211.28 146.93,211.83 147.61,212.59 147.95,212.97 148.91,213.91 148.98,213.97 150.00,214.83 150.53,215.22 151.02,215.58 152.05,216.21 152.67,216.54 153.07,216.74 154.09,217.19 155.12,217.54 156.14,217.81 156.35,217.85 157.17,218.01 158.19,218.14 159.21,218.20 160.24,218.20 161.26,218.13 162.28,218.01 163.16,217.85 163.31,217.83 164.33,217.60 165.35,217.32 166.38,216.99 167.40,216.61 167.57,216.54 168.43,216.19 169.45,215.72 170.44,215.22 170.47,215.21 171.50,214.66 172.52,214.06 172.77,213.91 173.54,213.43 174.57,212.76 174.80,212.59 175.59,212.04 176.62,211.29 176.63,211.28 177.64,210.50 178.30,209.96 178.66,209.67 179.69,208.79 179.85,208.65 180.71,207.88 181.31,207.33 181.73,206.93 182.68,206.02 182.76,205.93 183.78,204.90 183.97,204.70 184.80,203.81 185.20,203.38 185.83,202.68 186.36,202.07 186.85,201.49 187.47,200.75 187.88,200.25 188.52,199.44 188.90,198.95 189.52,198.12 189.92,197.57 190.47,196.81 190.95,196.12 191.38,195.49 191.97,194.58 192.23,194.18 192.99,192.94 193.04,192.86 193.80,191.55 194.02,191.15 194.52,190.23 195.04,189.19 195.18,188.92 195.80,187.60 196.07,186.99 196.37,186.29 196.89,184.97 197.09,184.41 197.36,183.66 197.78,182.34 198.11,181.12 198.14,181.03 198.45,179.71 198.70,178.40 198.88,177.08 199.01,175.76 199.06,174.45 199.05,173.13 198.95,171.82 198.77,170.50 198.50,169.19 198.13,167.87 198.11,167.83 197.64,166.56 197.09,165.37 197.03,165.24 196.27,163.93 196.07,163.64 195.33,162.61 195.04,162.27 194.18,161.30 194.02,161.13 192.99,160.18 192.78,159.98 191.97,159.35 191.04,158.67 190.95,158.60 189.92,157.96 188.90,157.38 188.86,157.35 187.88,156.86 186.85,156.39 186.01,156.04 185.83,155.96 184.80,155.58 183.78,155.24 182.76,154.92 182.08,154.72 181.73,154.63 180.71,154.37 179.69,154.14 178.66,153.92 177.64,153.73 176.62,153.56 175.60,153.41 175.59,153.40 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='31.30' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjYwLjg3fDQ4NC45NXw0MC4zNnwzMjguMjc='>
+    <rect x='260.87' y='40.36' width='224.09' height='287.90' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjYwLjg3fDQ4NC45NXw0MC4zNnwzMjguMjc=)'>
+<rect x='260.87' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='260.87,279.49 484.95,279.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,208.11 484.95,208.11 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,136.73 484.95,136.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,65.34 484.95,65.34 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='298.83,328.27 298.83,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='354.39,328.27 354.39,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='409.95,328.27 409.95,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='465.51,328.27 465.51,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,315.18 484.95,315.18 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,243.80 484.95,243.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,172.42 484.95,172.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,101.04 484.95,101.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='271.05,328.27 271.05,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='326.61,328.27 326.61,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='382.17,328.27 382.17,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.73,328.27 437.73,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<circle cx='443.13' cy='132.89' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='371.28' cy='195.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='364.56' cy='139.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='387.26' cy='163.60' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='383.72' cy='158.49' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='395.98' cy='170.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='399.66' cy='145.90' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='440.37' cy='113.37' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='368.60' cy='198.10' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='409.00' cy='116.31' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='401.07' cy='129.76' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='348.22' cy='187.82' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='362.98' cy='166.72' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='360.76' cy='202.08' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='422.74' cy='163.07' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='384.56' cy='172.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='386.07' cy='157.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='389.02' cy='153.27' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='388.39' cy='177.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='376.50' cy='197.93' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='414.29' cy='142.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='333.31' cy='274.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='374.10' cy='164.85' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='379.12' cy='178.64' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='336.94' cy='203.19' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='384.95' cy='185.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='380.93' cy='108.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='409.12' cy='170.00' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='367.78' cy='156.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='343.44' cy='177.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='391.13' cy='148.83' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='394.10' cy='174.43' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='401.72' cy='180.98' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='364.06' cy='228.13' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='381.65' cy='194.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='381.13' cy='142.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='361.02' cy='207.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='356.66' cy='213.79' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='352.96' cy='226.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='354.28' cy='221.67' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='399.98' cy='175.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='360.56' cy='168.70' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='353.59' cy='134.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='352.55' cy='184.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='437.36' cy='108.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='418.52' cy='177.10' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='412.61' cy='195.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='396.72' cy='132.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='371.90' cy='205.16' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='390.45' cy='219.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='375.47' cy='162.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='410.38' cy='178.74' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='400.11' cy='143.97' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='361.29' cy='199.74' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='356.17' cy='187.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='403.21' cy='186.36' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='388.69' cy='150.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='387.16' cy='165.69' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='391.76' cy='122.56' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='376.84' cy='178.13' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='397.27' cy='195.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='418.65' cy='181.24' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='400.04' cy='159.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='403.82' cy='148.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='353.99' cy='163.51' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='370.68' cy='186.99' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='383.12' cy='186.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='333.67' cy='208.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='369.96' cy='173.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='364.97' cy='193.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='377.03' cy='155.31' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='378.04' cy='220.19' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='382.24' cy='186.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='346.99' cy='213.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='350.57' cy='193.95' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='341.11' cy='232.68' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='398.72' cy='98.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='405.72' cy='163.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='356.16' cy='215.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='420.99' cy='170.94' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='380.09' cy='154.86' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='375.74' cy='161.83' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='408.68' cy='182.77' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='383.08' cy='190.75' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='371.99' cy='156.45' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='352.98' cy='174.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='352.71' cy='181.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='385.60' cy='151.87' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='382.76' cy='204.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='393.91' cy='198.79' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='414.16' cy='128.11' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='353.03' cy='180.55' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='395.76' cy='155.30' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='363.98' cy='201.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='390.01' cy='176.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='408.55' cy='184.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='385.31' cy='167.09' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='392.14' cy='187.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='414.41' cy='116.87' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='400.17' cy='157.06' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='394.24' cy='165.63' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='371.29' cy='163.62' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='361.03' cy='173.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='357.63' cy='169.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='396.90' cy='115.61' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='317.26' cy='230.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='347.30' cy='206.15' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='339.62' cy='225.48' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='351.19' cy='185.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='406.10' cy='150.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='414.58' cy='103.52' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='386.24' cy='186.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='394.27' cy='159.01' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='365.12' cy='239.60' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='456.55' cy='101.90' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='375.56' cy='220.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='365.37' cy='209.85' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='343.34' cy='176.57' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='398.83' cy='111.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='427.48' cy='191.02' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='333.45' cy='264.99' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='398.67' cy='151.53' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='432.10' cy='150.32' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='425.95' cy='96.90' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='381.51' cy='181.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='383.55' cy='197.72' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='383.20' cy='196.52' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='312.73' cy='299.30' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='408.90' cy='105.97' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='358.38' cy='161.03' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='371.56' cy='175.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='356.47' cy='196.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='384.49' cy='212.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='393.12' cy='127.30' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='440.89' cy='95.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='416.31' cy='136.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='418.38' cy='152.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='380.76' cy='171.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='348.35' cy='167.03' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='383.21' cy='177.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='395.44' cy='88.19' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='401.42' cy='189.09' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='405.88' cy='136.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='405.48' cy='213.41' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='414.91' cy='142.57' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='333.54' cy='247.63' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='393.40' cy='195.25' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='402.80' cy='149.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='401.90' cy='148.60' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='384.43' cy='186.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='370.01' cy='189.54' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='357.74' cy='191.13' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='413.35' cy='102.77' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='374.33' cy='153.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='336.83' cy='230.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='365.94' cy='191.79' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='342.14' cy='183.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='383.32' cy='197.50' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='369.11' cy='187.39' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='427.97' cy='140.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='412.96' cy='140.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='373.94' cy='193.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='383.49' cy='187.38' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='419.64' cy='121.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='427.03' cy='139.61' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='357.00' cy='193.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='365.03' cy='197.22' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='363.69' cy='176.94' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='387.25' cy='161.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='386.74' cy='184.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='396.01' cy='183.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='387.51' cy='161.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='393.20' cy='168.84' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='398.46' cy='130.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='381.93' cy='182.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='406.88' cy='125.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='401.40' cy='185.44' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='378.38' cy='145.41' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='354.80' cy='193.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='426.75' cy='145.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='365.80' cy='196.19' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='427.65' cy='100.93' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='367.48' cy='162.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='381.35' cy='151.98' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='369.68' cy='174.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='403.74' cy='127.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='391.62' cy='134.06' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='371.72' cy='170.52' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='413.90' cy='87.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='381.89' cy='137.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='305.05' cy='270.87' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='333.68' cy='214.24' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='365.60' cy='164.42' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='373.49' cy='150.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='335.53' cy='179.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='436.07' cy='116.41' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='383.70' cy='184.15' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='393.10' cy='162.89' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='395.79' cy='176.84' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='386.76' cy='129.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='399.14' cy='161.92' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='287.95' cy='242.27' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='397.13' cy='157.65' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='342.52' cy='245.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='383.84' cy='184.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='425.16' cy='151.71' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='391.61' cy='222.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='438.98' cy='94.68' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='408.06' cy='145.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='382.44' cy='160.92' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='400.29' cy='186.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='385.77' cy='175.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='405.79' cy='173.09' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='385.81' cy='196.38' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='331.81' cy='229.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='383.28' cy='149.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='402.48' cy='165.75' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='348.57' cy='226.24' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='391.37' cy='147.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='381.59' cy='173.95' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='354.46' cy='205.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='371.17' cy='181.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='356.66' cy='226.43' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='365.91' cy='186.31' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='361.99' cy='172.30' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='343.88' cy='190.11' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='437.66' cy='139.51' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='414.31' cy='134.27' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='393.42' cy='162.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='394.52' cy='177.28' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='363.78' cy='247.20' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='373.19' cy='197.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='401.08' cy='189.28' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='409.88' cy='162.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='357.76' cy='162.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='395.73' cy='110.52' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='406.88' cy='145.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='417.23' cy='152.62' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='344.80' cy='217.83' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='338.56' cy='237.79' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='336.35' cy='184.54' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='355.77' cy='179.20' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='376.71' cy='196.45' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='376.85' cy='134.57' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='347.81' cy='197.78' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='408.31' cy='199.07' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='374.52' cy='216.55' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='377.48' cy='152.13' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='417.71' cy='157.19' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='361.60' cy='209.22' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<polyline points='442.01,144.01 440.99,144.01 439.96,144.03 438.94,144.06 437.92,144.09 436.89,144.13 435.87,144.18 435.49,144.20 434.84,144.23 433.82,144.28 432.80,144.34 431.77,144.40 430.75,144.46 429.73,144.52 428.70,144.58 427.68,144.64 426.66,144.71 425.63,144.77 424.61,144.84 423.58,144.92 422.56,144.99 421.54,145.07 420.51,145.15 419.49,145.24 418.47,145.34 417.44,145.44 416.67,145.51 416.42,145.54 415.39,145.65 414.37,145.77 413.35,145.88 412.32,146.01 411.30,146.14 410.28,146.27 409.25,146.40 408.23,146.54 407.20,146.68 406.18,146.82 406.08,146.83 405.16,146.95 404.13,147.09 403.11,147.23 402.09,147.36 401.06,147.48 400.04,147.60 399.02,147.72 397.99,147.83 396.97,147.93 395.94,148.03 394.92,148.12 394.59,148.14 393.90,148.20 392.87,148.28 391.85,148.36 390.83,148.43 389.80,148.50 388.78,148.58 387.75,148.66 386.73,148.74 385.71,148.83 384.68,148.94 383.66,149.06 382.64,149.20 381.61,149.37 381.13,149.46 380.59,149.56 379.57,149.79 378.54,150.06 377.52,150.37 376.49,150.74 376.40,150.78 375.47,151.16 374.45,151.65 373.66,152.09 373.42,152.23 372.40,152.89 371.71,153.41 371.38,153.67 370.35,154.57 370.20,154.72 369.33,155.63 368.98,156.04 368.30,156.88 367.97,157.35 367.28,158.38 367.10,158.67 366.37,159.98 366.26,160.20 365.74,161.30 365.23,162.48 365.18,162.61 364.70,163.93 364.28,165.24 364.21,165.49 363.91,166.56 363.59,167.87 363.30,169.19 363.19,169.78 363.05,170.50 362.83,171.82 362.63,173.13 362.46,174.45 362.31,175.76 362.18,177.08 362.16,177.22 362.05,178.40 361.95,179.71 361.86,181.03 361.77,182.34 361.70,183.66 361.64,184.97 361.59,186.29 361.54,187.60 361.50,188.92 361.47,190.23 361.44,191.55 361.43,192.86 361.42,194.18 361.42,195.49 361.44,196.81 361.46,198.12 361.50,199.44 361.54,200.75 361.61,202.07 361.69,203.38 361.78,204.70 361.89,206.02 362.03,207.33 362.16,208.50 362.18,208.65 362.35,209.96 362.55,211.28 362.76,212.59 363.00,213.91 363.19,214.85 363.26,215.22 363.54,216.54 363.85,217.85 364.17,219.17 364.21,219.31 364.52,220.48 364.89,221.80 365.23,222.98 365.27,223.11 365.68,224.43 366.10,225.74 366.26,226.24 366.53,227.06 366.98,228.37 367.28,229.25 367.44,229.69 367.91,231.00 368.30,232.10 368.39,232.32 368.88,233.63 369.33,234.84 369.37,234.95 369.88,236.27 370.35,237.50 370.39,237.58 370.91,238.90 371.38,240.08 371.43,240.21 371.98,241.53 372.40,242.56 372.52,242.84 373.09,244.16 373.42,244.93 373.68,245.47 374.29,246.79 374.45,247.14 374.94,248.10 375.47,249.16 375.62,249.42 376.36,250.73 376.49,250.97 377.19,252.05 377.52,252.56 378.12,253.36 378.54,253.93 379.21,254.68 379.57,255.08 380.55,255.99 380.59,256.03 381.61,256.81 382.47,257.31 382.64,257.41 383.66,257.86 384.68,258.17 385.71,258.34 386.73,258.39 387.75,258.32 388.78,258.13 389.80,257.84 390.83,257.44 391.10,257.31 391.85,256.95 392.87,256.35 393.39,255.99 393.90,255.65 394.92,254.86 395.13,254.68 395.94,253.97 396.58,253.36 396.97,252.99 397.86,252.05 397.99,251.91 399.02,250.74 399.02,250.73 400.04,249.49 400.09,249.42 401.06,248.15 401.10,248.10 402.05,246.79 402.09,246.73 402.95,245.47 403.11,245.24 403.83,244.16 404.13,243.69 404.67,242.84 405.16,242.07 405.49,241.53 406.18,240.40 406.29,240.21 407.08,238.90 407.20,238.69 407.86,237.58 408.23,236.96 408.64,236.27 409.25,235.21 409.40,234.95 410.17,233.63 410.28,233.46 410.95,232.32 411.30,231.73 411.73,231.00 412.32,230.02 412.53,229.69 413.33,228.37 413.35,228.35 414.17,227.06 414.37,226.75 415.04,225.74 415.39,225.21 415.94,224.43 416.42,223.75 416.88,223.11 417.44,222.36 417.87,221.80 418.47,221.06 418.94,220.48 419.49,219.83 420.07,219.17 420.51,218.68 421.30,217.85 421.54,217.61 422.56,216.59 422.62,216.54 423.58,215.65 424.07,215.22 424.61,214.76 425.63,213.91 425.63,213.91 426.66,213.11 427.33,212.59 427.68,212.34 428.70,211.60 429.15,211.28 429.73,210.88 430.75,210.18 431.07,209.96 431.77,209.50 432.80,208.82 433.06,208.65 433.82,208.16 434.84,207.48 435.08,207.33 435.87,206.82 436.89,206.14 437.07,206.02 437.92,205.46 438.94,204.76 439.02,204.70 439.96,204.05 440.89,203.38 440.99,203.31 442.01,202.57 442.66,202.07 443.03,201.79 444.06,200.98 444.34,200.75 445.08,200.15 445.91,199.44 446.11,199.28 447.13,198.37 447.39,198.12 448.15,197.42 448.78,196.81 449.18,196.42 450.08,195.49 450.20,195.37 451.22,194.27 451.30,194.18 452.25,193.10 452.45,192.86 453.27,191.87 453.53,191.55 454.29,190.56 454.54,190.23 455.32,189.15 455.49,188.92 456.34,187.65 456.37,187.60 457.21,186.29 457.37,186.03 457.99,184.97 458.39,184.26 458.72,183.66 459.40,182.34 459.41,182.32 460.04,181.03 460.44,180.13 460.62,179.71 461.17,178.40 461.46,177.61 461.66,177.08 462.11,175.76 462.48,174.55 462.52,174.45 462.88,173.13 463.20,171.82 463.47,170.50 463.51,170.26 463.69,169.19 463.87,167.87 464.00,166.56 464.07,165.24 464.09,163.93 464.06,162.61 463.96,161.30 463.80,159.98 463.56,158.67 463.51,158.44 463.25,157.35 462.85,156.04 462.48,155.07 462.35,154.72 461.74,153.41 461.46,152.91 460.98,152.09 460.44,151.29 460.06,150.78 459.41,150.00 458.92,149.46 458.39,148.94 457.48,148.14 457.37,148.06 456.34,147.32 455.57,146.83 455.32,146.69 454.29,146.16 453.27,145.71 452.76,145.51 452.25,145.33 451.22,145.02 450.20,144.76 449.18,144.55 448.15,144.39 447.13,144.25 446.58,144.20 446.11,144.16 445.08,144.09 444.06,144.04 443.03,144.01 442.01,144.01 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='260.87' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkwLjQzfDcxNC41Mnw0MC4zNnwzMjguMjc='>
+    <rect x='490.43' y='40.36' width='224.09' height='287.90' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkwLjQzfDcxNC41Mnw0MC4zNnwzMjguMjc=)'>
+<rect x='490.43' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='490.43,279.49 714.52,279.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,208.11 714.52,208.11 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,136.73 714.52,136.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,65.34 714.52,65.34 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='528.40,328.27 528.40,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='583.96,328.27 583.96,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='639.52,328.27 639.52,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='695.08,328.27 695.08,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,315.18 714.52,315.18 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,243.80 714.52,243.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,172.42 714.52,172.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,101.04 714.52,101.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='500.62,328.27 500.62,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='556.18,328.27 556.18,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='611.74,328.27 611.74,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='667.30,328.27 667.30,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<circle cx='672.70' cy='132.89' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='600.84' cy='195.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='594.12' cy='139.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='616.82' cy='163.60' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='613.28' cy='158.49' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='625.55' cy='170.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='629.23' cy='145.90' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='669.93' cy='113.37' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='598.16' cy='198.10' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='638.56' cy='116.31' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='630.64' cy='129.76' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='577.79' cy='187.82' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='592.55' cy='166.72' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='590.33' cy='202.08' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='652.31' cy='163.07' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='614.13' cy='172.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='615.63' cy='157.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='618.59' cy='153.27' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='617.96' cy='177.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='606.06' cy='197.93' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='643.85' cy='142.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='562.87' cy='274.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='603.67' cy='164.85' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='608.68' cy='178.64' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='566.50' cy='203.19' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='614.52' cy='185.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='610.50' cy='108.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='638.69' cy='170.00' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='597.35' cy='156.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='573.01' cy='177.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='620.70' cy='148.83' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='623.67' cy='174.43' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='631.28' cy='180.98' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='593.62' cy='228.13' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='611.21' cy='194.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='610.70' cy='142.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='590.59' cy='207.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='586.23' cy='213.79' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='582.53' cy='226.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.85' cy='221.67' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='629.54' cy='175.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='590.13' cy='168.70' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.16' cy='134.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='582.12' cy='184.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='666.92' cy='108.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='648.09' cy='177.10' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='642.18' cy='195.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='626.28' cy='132.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='601.47' cy='205.16' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='620.01' cy='219.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='605.04' cy='162.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='639.94' cy='178.74' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='629.68' cy='143.97' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='590.86' cy='199.74' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='585.74' cy='187.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='632.78' cy='186.36' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='618.26' cy='150.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='616.73' cy='165.69' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='621.33' cy='122.56' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='606.41' cy='178.13' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='626.83' cy='195.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='648.21' cy='181.24' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='629.61' cy='159.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='633.38' cy='148.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.56' cy='163.51' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='600.25' cy='186.99' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='612.68' cy='186.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='563.23' cy='208.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='599.52' cy='173.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='594.53' cy='193.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='606.59' cy='155.31' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='607.60' cy='220.19' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='611.81' cy='186.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='576.55' cy='213.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='580.14' cy='193.95' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='570.67' cy='232.68' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='628.28' cy='98.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='635.29' cy='163.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='585.72' cy='215.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='650.55' cy='170.94' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='609.66' cy='154.86' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='605.31' cy='161.83' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='638.24' cy='182.77' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='612.64' cy='190.75' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='601.56' cy='156.45' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='582.54' cy='174.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='582.28' cy='181.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='615.17' cy='151.87' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='612.32' cy='204.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='623.48' cy='198.79' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='643.73' cy='128.11' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='582.59' cy='180.55' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='625.32' cy='155.30' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='593.55' cy='201.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='619.58' cy='176.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='638.11' cy='184.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='614.87' cy='167.09' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='621.71' cy='187.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='643.97' cy='116.87' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='629.73' cy='157.06' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='623.81' cy='165.63' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='600.86' cy='163.62' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='590.59' cy='173.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='587.20' cy='169.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='626.46' cy='115.61' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='546.82' cy='230.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='576.87' cy='206.15' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='569.19' cy='225.48' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='580.75' cy='185.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='635.67' cy='150.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='644.15' cy='103.52' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='615.80' cy='186.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='623.84' cy='159.01' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='594.69' cy='239.60' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='686.12' cy='101.90' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='605.12' cy='220.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='594.93' cy='209.85' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='572.90' cy='176.57' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='628.40' cy='111.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='657.05' cy='191.02' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='563.02' cy='264.99' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='628.24' cy='151.53' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='661.67' cy='150.32' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='655.52' cy='96.90' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='611.08' cy='181.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='613.12' cy='197.72' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='612.77' cy='196.52' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='542.30' cy='299.30' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='638.46' cy='105.97' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='587.95' cy='161.03' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='601.13' cy='175.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='586.04' cy='196.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='614.06' cy='212.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='622.69' cy='127.30' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='670.46' cy='95.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='645.87' cy='136.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='647.95' cy='152.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='610.33' cy='171.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='577.91' cy='167.03' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='612.78' cy='177.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='625.01' cy='88.19' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='630.98' cy='189.09' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='635.45' cy='136.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='635.04' cy='213.41' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='644.47' cy='142.57' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='563.11' cy='247.63' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='622.96' cy='195.25' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='632.36' cy='149.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='631.47' cy='148.60' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='613.99' cy='186.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='599.58' cy='189.54' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='587.31' cy='191.13' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='642.91' cy='102.77' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='603.89' cy='153.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='566.39' cy='230.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='595.51' cy='191.79' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='571.71' cy='183.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='612.89' cy='197.50' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='598.68' cy='187.39' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='657.53' cy='140.38' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='642.53' cy='140.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='603.51' cy='193.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='613.06' cy='187.38' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='649.20' cy='121.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='656.59' cy='139.61' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='586.56' cy='193.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='594.60' cy='197.22' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='593.26' cy='176.94' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='616.82' cy='161.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='616.30' cy='184.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='625.57' cy='183.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='617.08' cy='161.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='622.77' cy='168.84' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='628.03' cy='130.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='611.49' cy='182.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='636.45' cy='125.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='630.96' cy='185.44' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='607.95' cy='145.41' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='584.37' cy='193.94' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='656.31' cy='145.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='595.37' cy='196.19' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='657.22' cy='100.93' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='597.05' cy='162.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='610.91' cy='151.98' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='599.25' cy='174.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='633.30' cy='127.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='621.19' cy='134.06' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='601.29' cy='170.52' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='643.47' cy='87.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='611.46' cy='137.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='534.62' cy='270.87' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='563.25' cy='214.24' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='595.17' cy='164.42' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='603.05' cy='150.14' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='565.10' cy='179.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='665.64' cy='116.41' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='613.27' cy='184.15' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='622.67' cy='162.89' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='625.36' cy='176.84' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='616.33' cy='129.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='628.71' cy='161.92' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='517.52' cy='242.27' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='626.70' cy='157.65' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='572.08' cy='245.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='613.40' cy='184.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='654.72' cy='151.71' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='621.18' cy='222.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='668.55' cy='94.68' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='637.62' cy='145.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='612.00' cy='160.92' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='629.85' cy='186.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='615.34' cy='175.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='635.36' cy='173.09' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='615.38' cy='196.38' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='561.38' cy='229.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='612.85' cy='149.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='632.05' cy='165.75' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='578.14' cy='226.24' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='620.94' cy='147.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='611.16' cy='173.95' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='584.03' cy='205.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='600.74' cy='181.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='586.23' cy='226.43' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='595.47' cy='186.31' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='591.56' cy='172.30' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='573.45' cy='190.11' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='667.23' cy='139.51' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='643.88' cy='134.27' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='622.98' cy='162.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='624.09' cy='177.28' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='593.35' cy='247.20' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='602.76' cy='197.23' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='630.64' cy='189.28' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='639.45' cy='162.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='587.33' cy='162.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='625.29' cy='110.52' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='636.45' cy='145.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='646.80' cy='152.62' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='574.36' cy='217.83' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='568.13' cy='237.79' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='565.91' cy='184.54' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='585.34' cy='179.20' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='606.28' cy='196.45' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='606.42' cy='134.57' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='577.38' cy='197.78' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='637.87' cy='199.07' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='604.08' cy='216.55' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='607.05' cy='152.13' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='647.27' cy='157.19' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='591.17' cy='209.22' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<polyline points='622.68,53.45 622.44,53.48 621.42,53.65 620.39,53.84 619.37,54.06 618.34,54.31 617.32,54.58 616.70,54.76 616.30,54.87 615.27,55.18 614.25,55.50 613.23,55.85 612.58,56.08 612.20,56.21 611.18,56.56 610.15,56.93 609.13,57.31 608.91,57.39 608.11,57.68 607.08,58.04 606.06,58.41 605.19,58.71 605.04,58.76 604.01,59.09 602.99,59.42 601.97,59.74 601.01,60.02 600.94,60.04 599.92,60.33 598.89,60.61 597.87,60.88 596.85,61.16 596.22,61.34 595.82,61.45 594.80,61.73 593.78,62.02 592.75,62.34 591.84,62.65 591.73,62.69 590.70,63.05 589.68,63.46 588.66,63.92 588.55,63.97 587.63,64.41 586.61,64.98 586.13,65.28 585.59,65.63 584.56,66.37 584.28,66.60 583.54,67.23 582.83,67.92 582.52,68.25 581.69,69.23 581.49,69.49 580.79,70.55 580.47,71.11 580.09,71.86 579.55,73.18 579.44,73.52 579.16,74.49 578.90,75.81 578.76,77.12 578.71,78.44 578.75,79.75 578.87,81.07 579.05,82.38 579.30,83.70 579.44,84.30 579.60,85.01 579.95,86.33 580.34,87.64 580.47,88.03 580.76,88.96 581.21,90.27 581.49,91.04 581.68,91.59 582.18,92.90 582.52,93.77 582.69,94.22 583.21,95.54 583.54,96.34 583.74,96.85 584.28,98.17 584.56,98.83 584.83,99.48 585.38,100.80 585.59,101.29 585.94,102.11 586.48,103.43 586.61,103.74 587.03,104.74 587.57,106.06 587.63,106.21 588.12,107.37 588.64,108.69 588.66,108.73 589.18,110.00 589.68,111.32 589.68,111.33 590.20,112.63 590.67,113.95 590.70,114.04 591.17,115.26 591.62,116.58 591.73,116.93 592.07,117.89 592.49,119.21 592.75,120.12 592.89,120.52 593.28,121.84 593.61,123.16 593.78,123.93 593.92,124.47 594.22,125.79 594.45,127.10 594.63,128.42 594.76,129.73 594.80,130.50 594.84,131.05 594.85,132.36 594.80,133.25 594.78,133.68 594.63,134.99 594.36,136.31 593.93,137.62 593.78,137.96 593.37,138.94 592.75,140.00 592.61,140.25 591.73,141.52 591.70,141.57 590.70,142.83 590.66,142.88 589.68,144.03 589.55,144.20 588.66,145.21 588.41,145.51 587.63,146.40 587.28,146.83 586.61,147.64 586.22,148.14 585.59,148.99 585.26,149.46 584.56,150.50 584.39,150.78 583.65,152.09 583.54,152.30 583.03,153.41 582.52,154.64 582.48,154.72 582.08,156.04 581.73,157.35 581.49,158.52 581.46,158.67 581.28,159.98 581.15,161.30 581.04,162.61 580.93,163.93 580.76,165.24 580.47,166.33 580.40,166.56 579.62,167.87 579.44,168.03 578.42,168.86 577.94,169.19 577.40,169.45 576.37,169.92 575.35,170.34 574.96,170.50 574.33,170.71 573.30,171.05 572.28,171.37 571.25,171.68 570.82,171.82 570.23,171.98 569.21,172.26 568.18,172.52 567.16,172.79 566.14,173.05 565.80,173.13 565.11,173.30 564.09,173.55 563.07,173.79 562.04,174.02 561.02,174.26 560.21,174.45 559.99,174.50 558.97,174.74 557.95,174.97 556.92,175.20 555.90,175.43 554.88,175.68 554.50,175.76 553.85,175.92 552.83,176.17 551.80,176.42 550.78,176.67 549.76,176.94 549.23,177.08 548.73,177.22 547.71,177.51 546.69,177.81 545.66,178.13 544.84,178.40 544.64,178.47 543.61,178.83 542.59,179.21 541.57,179.63 541.37,179.71 540.54,180.09 539.52,180.59 538.69,181.03 538.50,181.14 537.47,181.77 536.60,182.34 536.45,182.46 535.43,183.26 534.95,183.66 534.40,184.19 533.63,184.97 533.38,185.28 532.56,186.29 532.35,186.60 531.69,187.60 531.33,188.27 530.98,188.92 530.40,190.23 530.31,190.50 529.92,191.55 529.55,192.86 529.28,194.08 529.26,194.18 529.03,195.49 528.87,196.81 528.76,198.12 528.71,199.44 528.71,200.75 528.74,202.07 528.81,203.38 528.92,204.70 529.06,206.02 529.22,207.33 529.28,207.76 529.40,208.65 529.59,209.96 529.80,211.28 530.02,212.59 530.24,213.91 530.31,214.30 530.45,215.22 530.66,216.54 530.85,217.85 531.04,219.17 531.20,220.48 531.33,221.63 531.35,221.80 531.47,223.11 531.56,224.43 531.64,225.74 531.71,227.06 531.75,228.37 531.79,229.69 531.82,231.00 531.84,232.32 531.87,233.63 531.90,234.95 531.93,236.27 531.98,237.58 532.04,238.90 532.12,240.21 532.21,241.53 532.33,242.84 532.35,243.09 532.46,244.16 532.61,245.47 532.79,246.79 532.99,248.10 533.23,249.42 533.38,250.15 533.49,250.73 533.77,252.05 534.09,253.36 534.40,254.50 534.45,254.68 534.82,255.99 535.24,257.31 535.43,257.84 535.69,258.62 536.18,259.94 536.45,260.61 536.71,261.25 537.28,262.57 537.47,262.99 537.89,263.89 538.50,265.09 538.55,265.20 539.26,266.52 539.52,266.96 540.03,267.83 540.54,268.65 540.86,269.15 541.57,270.18 541.77,270.46 542.59,271.57 542.75,271.78 543.61,272.84 543.83,273.09 544.64,273.99 545.04,274.41 545.66,275.04 546.40,275.72 546.69,275.98 547.71,276.83 547.98,277.04 548.73,277.60 549.76,278.26 549.93,278.35 550.78,278.84 551.80,279.32 552.73,279.67 552.83,279.71 553.85,280.02 554.88,280.22 555.90,280.33 556.92,280.33 557.95,280.22 558.97,279.99 559.90,279.67 559.99,279.64 561.02,279.19 562.04,278.59 562.36,278.35 563.07,277.87 564.05,277.04 564.09,277.01 565.11,276.04 565.39,275.72 566.14,274.95 566.57,274.41 567.16,273.74 567.65,273.09 568.18,272.44 568.65,271.78 569.21,271.04 569.60,270.46 570.23,269.58 570.51,269.15 571.25,268.06 571.40,267.83 572.26,266.52 572.28,266.49 573.10,265.20 573.30,264.91 573.94,263.89 574.33,263.31 574.78,262.57 575.35,261.69 575.61,261.25 576.37,260.06 576.44,259.94 577.27,258.62 577.40,258.43 578.10,257.31 578.42,256.81 578.94,255.99 579.44,255.21 579.78,254.68 580.47,253.62 580.63,253.36 581.48,252.05 581.49,252.04 582.34,250.73 582.52,250.48 583.22,249.42 583.54,248.94 584.11,248.10 584.56,247.43 585.01,246.79 585.59,245.96 585.94,245.47 586.61,244.52 586.88,244.16 587.63,243.11 587.85,242.84 588.66,241.75 588.84,241.53 589.68,240.43 589.86,240.21 590.70,239.15 590.92,238.90 591.73,237.90 592.02,237.58 592.75,236.69 593.15,236.27 593.78,235.51 594.30,234.95 594.80,234.34 595.44,233.63 595.82,233.15 596.54,232.32 596.85,231.90 597.55,231.00 597.87,230.50 598.41,229.69 598.89,228.76 599.10,228.37 599.56,227.06 599.81,225.74 599.80,224.43 599.52,223.11 598.94,221.80 598.89,221.72 597.87,220.53 597.80,220.48 596.85,219.87 595.82,219.51 594.80,219.36 593.78,219.37 592.75,219.48 591.73,219.66 590.70,219.87 589.68,220.08 588.66,220.27 587.63,220.42 586.98,220.48 586.61,220.51 585.59,220.53 584.60,220.48 584.56,220.48 583.54,220.31 582.52,220.03 581.49,219.61 580.72,219.17 580.47,218.96 579.47,217.85 579.44,217.80 579.02,216.54 579.06,215.22 579.44,213.91 579.44,213.91 580.16,212.59 580.47,212.15 581.10,211.28 581.49,210.81 582.22,209.96 582.52,209.64 583.46,208.65 583.54,208.56 584.56,207.54 584.77,207.33 585.59,206.52 586.08,206.02 586.61,205.46 587.32,204.70 587.63,204.33 588.44,203.38 588.66,203.08 589.41,202.07 589.68,201.63 590.23,200.75 590.70,199.78 590.88,199.44 591.38,198.12 591.72,196.81 591.73,196.75 591.94,195.49 592.01,194.18 591.94,192.86 591.73,191.56 591.73,191.55 591.44,190.23 591.03,188.92 590.70,188.07 590.55,187.60 590.03,186.29 589.68,185.51 589.47,184.97 588.89,183.66 588.66,183.13 588.32,182.34 587.76,181.03 587.63,180.73 587.23,179.71 586.71,178.40 586.61,178.10 586.25,177.08 585.84,175.76 585.59,174.74 585.51,174.45 585.29,173.13 585.25,171.82 585.56,170.50 585.59,170.45 586.43,169.19 586.61,169.03 587.63,168.17 588.00,167.87 588.66,167.44 589.68,166.75 589.95,166.56 590.70,166.06 591.73,165.33 591.84,165.24 592.75,164.54 593.47,163.93 593.78,163.66 594.80,162.64 594.83,162.61 595.82,161.42 595.92,161.30 596.80,159.98 596.85,159.90 597.53,158.67 597.87,157.91 598.12,157.35 598.62,156.04 598.89,155.17 599.04,154.72 599.42,153.41 599.76,152.09 599.92,151.39 600.07,150.78 600.39,149.46 600.69,148.14 600.94,147.12 601.02,146.83 601.38,145.51 601.77,144.20 601.97,143.57 602.20,142.88 602.66,141.57 602.99,140.63 603.13,140.25 603.57,138.94 603.97,137.62 604.01,137.47 604.30,136.31 604.56,134.99 604.76,133.68 604.91,132.36 605.04,131.05 605.04,131.04 605.14,129.73 605.24,128.42 605.34,127.10 605.47,125.79 605.61,124.47 605.78,123.16 605.99,121.84 606.06,121.51 606.26,120.52 606.59,119.21 606.98,117.89 607.08,117.61 607.51,116.58 608.11,115.41 608.20,115.26 609.13,114.14 609.41,113.95 610.15,113.53 611.18,113.43 612.20,113.78 612.43,113.95 613.23,114.57 613.82,115.26 614.25,115.78 614.75,116.58 615.27,117.46 615.49,117.89 616.08,119.21 616.30,119.73 616.58,120.52 617.01,121.84 617.32,122.88 617.39,123.16 617.69,124.47 617.94,125.79 618.13,127.10 618.28,128.42 618.34,129.51 618.36,129.73 618.37,131.05 618.34,131.81 618.32,132.36 618.20,133.68 618.02,134.99 617.80,136.31 617.56,137.62 617.33,138.94 617.32,138.98 617.15,140.25 617.08,141.57 617.15,142.88 617.32,143.74 617.42,144.20 617.94,145.51 618.34,146.17 618.86,146.83 619.37,147.30 620.39,147.92 621.13,148.14 621.42,148.22 622.44,148.24 623.00,148.14 623.46,148.06 624.49,147.67 625.51,147.11 625.90,146.83 626.53,146.40 627.56,145.57 627.61,145.51 628.58,144.72 629.18,144.20 629.61,143.89 630.63,143.14 630.99,142.88 631.65,142.51 632.68,141.97 633.57,141.57 633.70,141.52 634.72,141.21 635.75,140.99 636.77,140.86 637.79,140.82 638.82,140.89 639.84,141.06 640.87,141.33 641.52,141.57 641.89,141.72 642.91,142.27 643.93,142.88 643.94,142.89 644.96,143.69 645.57,144.20 645.98,144.58 646.99,145.51 647.01,145.53 648.03,146.55 648.33,146.83 649.06,147.53 649.80,148.14 650.08,148.38 651.10,149.10 651.76,149.46 652.13,149.65 653.15,150.08 654.17,150.38 655.20,150.58 656.22,150.70 657.24,150.75 658.27,150.76 659.29,150.71 660.32,150.63 661.34,150.51 662.36,150.36 663.39,150.18 664.41,149.97 665.43,149.73 666.41,149.46 666.46,149.45 667.48,149.14 668.51,148.81 669.53,148.45 670.30,148.14 670.55,148.04 671.58,147.61 672.60,147.15 673.24,146.83 673.62,146.63 674.65,146.09 675.66,145.51 675.67,145.51 676.70,144.88 677.72,144.20 677.73,144.20 678.74,143.48 679.54,142.88 679.77,142.70 680.79,141.88 681.16,141.57 681.81,140.99 682.63,140.25 682.84,140.05 683.86,139.04 683.96,138.94 684.88,137.96 685.20,137.62 685.91,136.80 686.34,136.31 686.93,135.56 687.40,134.99 687.96,134.24 688.39,133.68 688.98,132.82 689.31,132.36 690.00,131.29 690.17,131.05 690.98,129.73 691.03,129.64 691.75,128.42 692.05,127.84 692.47,127.10 693.07,125.90 693.14,125.79 693.78,124.47 694.10,123.74 694.38,123.16 694.93,121.84 695.12,121.33 695.46,120.52 695.94,119.21 696.15,118.58 696.39,117.89 696.81,116.58 697.17,115.29 697.18,115.26 697.53,113.95 697.84,112.63 698.10,111.32 698.19,110.72 698.33,110.00 698.52,108.69 698.66,107.37 698.75,106.06 698.80,104.74 698.79,103.43 698.73,102.11 698.61,100.80 698.43,99.48 698.19,98.29 698.17,98.17 697.86,96.85 697.46,95.54 697.17,94.75 696.98,94.22 696.41,92.90 696.15,92.38 695.74,91.59 695.12,90.53 694.97,90.27 694.10,88.98 694.08,88.96 693.08,87.64 693.07,87.63 692.05,86.44 691.95,86.33 691.03,85.35 690.69,85.01 690.00,84.36 689.27,83.70 688.98,83.44 687.96,82.58 687.71,82.38 686.93,81.77 686.00,81.07 685.91,81.00 684.88,80.26 684.15,79.75 683.86,79.56 682.84,78.87 682.17,78.44 681.81,78.21 680.79,77.56 680.08,77.12 679.77,76.93 678.74,76.29 677.92,75.81 677.72,75.68 676.70,75.06 675.71,74.49 675.67,74.47 674.65,73.84 673.62,73.25 673.51,73.18 672.60,72.62 671.58,72.02 671.32,71.86 670.55,71.39 669.53,70.77 669.16,70.55 668.51,70.13 667.48,69.50 667.04,69.23 666.46,68.86 665.43,68.21 664.95,67.92 664.41,67.56 663.39,66.91 662.89,66.60 662.36,66.26 661.34,65.60 660.84,65.28 660.32,64.95 659.29,64.30 658.77,63.97 658.27,63.65 657.24,63.01 656.66,62.65 656.22,62.38 655.20,61.76 654.48,61.34 654.17,61.16 653.15,60.55 652.18,60.02 652.13,59.99 651.10,59.41 650.08,58.88 649.73,58.71 649.06,58.35 648.03,57.85 647.03,57.39 647.01,57.38 645.98,56.91 644.96,56.47 643.94,56.08 643.94,56.08 642.91,55.68 641.89,55.31 640.87,54.98 640.12,54.76 639.84,54.68 638.82,54.38 637.79,54.12 636.77,53.89 635.75,53.69 634.72,53.51 634.26,53.45 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='490.43' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzEuMzB8MjU1LjM5fDIzLjM0fDQwLjM2'>
+    <rect x='31.30' y='23.34' width='224.09' height='17.03' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzEuMzB8MjU1LjM5fDIzLjM0fDQwLjM2)'>
+<rect x='31.30' y='23.34' width='224.09' height='17.03' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='143.35' y='35.00' text-anchor='middle' style='font-size: 8.80px;fill: #1A1A1A; font-family: "Arial";' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>underfit</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjYwLjg3fDQ4NC45NXwyMy4zNHw0MC4zNg=='>
+    <rect x='260.87' y='23.34' width='224.09' height='17.03' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjYwLjg3fDQ4NC45NXwyMy4zNHw0MC4zNg==)'>
+<rect x='260.87' y='23.34' width='224.09' height='17.03' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='372.91' y='35.00' text-anchor='middle' style='font-size: 8.80px;fill: #1A1A1A; font-family: "Arial";' textLength='41.58px' lengthAdjust='spacingAndGlyphs'>about right</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkwLjQzfDcxNC41MnwyMy4zNHw0MC4zNg=='>
+    <rect x='490.43' y='23.34' width='224.09' height='17.03' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkwLjQzfDcxNC41MnwyMy4zNHw0MC4zNg==)'>
+<rect x='490.43' y='23.34' width='224.09' height='17.03' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='602.48' y='35.00' text-anchor='middle' style='font-size: 8.80px;fill: #1A1A1A; font-family: "Arial";' textLength='23.95px' lengthAdjust='spacingAndGlyphs'>overfit</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+<polyline points='41.49,331.01 41.49,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='97.05,331.01 97.05,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='152.60,331.01 152.60,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='208.16,331.01 208.16,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='41.49' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-6</text>
+<text x='97.05' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='152.60' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='208.16' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<polyline points='271.05,331.01 271.05,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='326.61,331.01 326.61,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='382.17,331.01 382.17,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='437.73,331.01 437.73,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='271.05' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-6</text>
+<text x='326.61' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='382.17' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='437.73' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<polyline points='500.62,331.01 500.62,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='556.18,331.01 556.18,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='611.74,331.01 611.74,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='667.30,331.01 667.30,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='500.62' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-6</text>
+<text x='556.18' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='611.74' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='667.30' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='26.37' y='318.33' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-6</text>
+<text x='26.37' y='246.95' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='26.37' y='175.57' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='26.37' y='104.19' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<polyline points='28.56,315.18 31.30,315.18 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.56,243.80 31.30,243.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.56,172.42 31.30,172.42 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.56,101.04 31.30,101.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='372.91' y='352.09' text-anchor='middle' style='font-size: 11.00px; font-family: "Arial";' textLength='54.41px' lengthAdjust='spacingAndGlyphs'>Predictor A</text>
+<text transform='translate(13.37,184.31) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Arial";' textLength='54.41px' lengthAdjust='spacingAndGlyphs'>Predictor B</text>
+<text x='31.30' y='14.94' style='font-size: 13.20px; font-family: "Arial";' textLength='49.12px' lengthAdjust='spacingAndGlyphs'>Test Set</text>
+</g>
+</svg>

--- a/slides/figures/overfitting-train-1.svg
+++ b/slides/figures/overfitting-train-1.svg
@@ -1,0 +1,928 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='720.00pt' height='360.00pt' viewBox='0 0 720.00 360.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='360.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='360.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzEuMzB8MjU1LjM5fDQwLjM2fDMyOC4yNw=='>
+    <rect x='31.30' y='40.36' width='224.09' height='287.90' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzEuMzB8MjU1LjM5fDQwLjM2fDMyOC4yNw==)'>
+<rect x='31.30' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='31.30,279.49 255.39,279.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,208.11 255.39,208.11 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,136.73 255.39,136.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,65.34 255.39,65.34 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='69.27,328.27 69.27,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='124.83,328.27 124.83,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='180.38,328.27 180.38,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='235.94,328.27 235.94,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,315.18 255.39,315.18 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,243.80 255.39,243.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,172.42 255.39,172.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='31.30,101.04 255.39,101.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='41.49,328.27 41.49,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='97.05,328.27 97.05,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='152.60,328.27 152.60,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='208.16,328.27 208.16,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<circle cx='192.70' cy='97.10' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='188.48' cy='81.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='131.72' cy='199.53' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='132.96' cy='163.21' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='176.73' cy='153.56' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='121.81' cy='198.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='188.24' cy='140.60' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='110.51' cy='229.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='162.66' cy='145.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='189.73' cy='146.65' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='171.02' cy='116.83' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='134.78' cy='220.23' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='166.94' cy='135.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='100.55' cy='211.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='85.44' cy='249.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='160.04' cy='143.00' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='190.59' cy='133.96' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='172.08' cy='152.23' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='164.55' cy='141.12' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='138.31' cy='163.03' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='120.65' cy='206.89' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='88.63' cy='246.45' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='163.67' cy='116.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='149.83' cy='167.23' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='159.02' cy='124.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='104.42' cy='245.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='200.57' cy='93.65' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='118.86' cy='191.60' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='139.16' cy='154.26' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='173.37' cy='136.97' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='167.87' cy='147.76' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='115.50' cy='212.99' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='183.46' cy='110.52' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='187.18' cy='129.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='107.45' cy='228.40' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='135.89' cy='128.07' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='199.17' cy='132.88' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='106.94' cy='204.30' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='106.45' cy='247.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='130.93' cy='170.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='175.32' cy='138.02' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='132.70' cy='198.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.60' cy='161.18' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='104.23' cy='220.93' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.96' cy='231.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='91.68' cy='213.56' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='237.51' cy='97.16' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='130.53' cy='187.89' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='148.78' cy='141.16' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='137.20' cy='144.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='102.20' cy='195.63' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.35' cy='248.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='116.63' cy='190.07' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='197.96' cy='134.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='125.69' cy='182.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='203.56' cy='113.03' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='184.36' cy='130.54' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='193.21' cy='105.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='117.55' cy='187.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='161.16' cy='138.06' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='173.00' cy='102.69' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='170.45' cy='134.27' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='197.53' cy='141.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='183.19' cy='119.88' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='185.61' cy='120.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='128.26' cy='188.91' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.83' cy='174.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='106.35' cy='232.96' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='165.62' cy='143.02' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='99.08' cy='234.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='116.82' cy='170.59' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='107.89' cy='203.42' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='109.67' cy='174.78' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='164.13' cy='115.69' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='127.60' cy='179.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='133.39' cy='227.19' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.18' cy='187.41' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='125.54' cy='150.98' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='115.21' cy='185.88' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='181.62' cy='140.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='172.19' cy='117.54' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='204.46' cy='93.29' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='211.62' cy='106.79' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='168.48' cy='120.59' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='144.07' cy='135.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='194.43' cy='88.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='138.62' cy='182.76' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.52' cy='177.66' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='174.73' cy='137.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='170.77' cy='130.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='157.81' cy='148.42' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='135.72' cy='137.20' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='115.53' cy='199.59' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='203.54' cy='96.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='123.98' cy='220.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='164.14' cy='138.33' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='162.70' cy='121.33' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='181.13' cy='126.44' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='161.04' cy='156.25' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='159.13' cy='110.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='119.66' cy='191.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='125.62' cy='184.16' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='192.75' cy='128.74' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='182.17' cy='137.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='119.31' cy='190.63' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='123.92' cy='228.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='172.36' cy='134.04' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='175.53' cy='104.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='154.10' cy='148.98' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='86.37' cy='231.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='115.09' cy='193.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='158.66' cy='104.31' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='103.57' cy='249.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='185.07' cy='79.43' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.25' cy='193.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='174.03' cy='131.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='155.57' cy='110.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='124.73' cy='163.92' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='187.94' cy='83.06' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='205.53' cy='142.15' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='145.56' cy='140.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='157.97' cy='152.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='179.75' cy='162.57' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='183.37' cy='153.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='182.28' cy='165.84' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='172.53' cy='177.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='176.65' cy='152.87' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='152.74' cy='179.43' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='158.73' cy='158.49' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='184.25' cy='176.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='164.78' cy='181.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='144.39' cy='174.01' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='166.71' cy='171.04' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='162.64' cy='184.51' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='163.61' cy='180.53' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='203.20' cy='180.88' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='162.07' cy='165.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='151.01' cy='132.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='146.97' cy='178.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='164.61' cy='198.11' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='189.01' cy='157.43' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='134.29' cy='183.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='166.09' cy='150.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='155.70' cy='193.00' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='141.73' cy='217.42' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='156.20' cy='197.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='130.61' cy='140.24' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='205.33' cy='151.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='172.22' cy='153.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='177.08' cy='159.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='188.94' cy='173.40' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='138.26' cy='181.93' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='194.41' cy='156.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='164.31' cy='152.85' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='140.37' cy='202.88' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='144.21' cy='156.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='145.08' cy='172.70' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='131.79' cy='187.87' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='147.30' cy='179.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='172.42' cy='159.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='119.78' cy='160.49' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='169.26' cy='186.69' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='151.38' cy='203.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='174.59' cy='173.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='138.36' cy='203.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='144.07' cy='186.89' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='158.02' cy='179.33' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='143.14' cy='166.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='169.10' cy='174.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='159.63' cy='176.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='148.54' cy='245.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='144.26' cy='146.45' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='143.59' cy='166.38' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='210.07' cy='149.62' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='149.91' cy='144.39' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='146.20' cy='173.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='188.02' cy='152.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='145.73' cy='178.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='155.87' cy='177.64' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='148.00' cy='205.55' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='183.88' cy='146.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='139.79' cy='180.99' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='163.82' cy='157.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='162.03' cy='162.47' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='170.83' cy='169.80' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='164.61' cy='177.57' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='160.07' cy='163.46' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='130.43' cy='164.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='171.03' cy='184.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='183.23' cy='152.10' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='177.46' cy='185.32' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='151.50' cy='157.18' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='143.87' cy='210.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='188.36' cy='174.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='135.42' cy='236.72' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='141.72' cy='171.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='129.68' cy='209.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='135.48' cy='203.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='151.59' cy='214.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='153.24' cy='146.12' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='134.16' cy='170.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='146.69' cy='191.93' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='150.86' cy='198.53' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='171.11' cy='191.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='175.93' cy='176.80' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='164.54' cy='161.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='159.27' cy='188.44' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='174.27' cy='157.50' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='212.15' cy='150.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='156.86' cy='171.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='135.83' cy='175.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='154.15' cy='192.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='141.14' cy='189.94' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='156.56' cy='158.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='162.25' cy='173.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='193.71' cy='157.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='168.03' cy='166.51' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='139.94' cy='181.80' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='174.19' cy='166.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='149.94' cy='214.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='201.53' cy='159.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='141.87' cy='171.11' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='138.34' cy='204.74' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='182.31' cy='169.55' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='167.08' cy='190.25' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='147.98' cy='204.25' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='182.58' cy='148.91' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='184.79' cy='148.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='164.77' cy='144.30' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='194.82' cy='156.46' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='147.19' cy='183.60' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='165.15' cy='188.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='141.75' cy='166.64' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='166.11' cy='201.02' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='202.45' cy='162.07' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='158.40' cy='173.52' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='175.46' cy='161.24' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='155.21' cy='186.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='149.04' cy='178.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='173.92' cy='181.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='182.27' cy='153.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='188.23' cy='164.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='174.76' cy='153.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='170.18' cy='208.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='178.12' cy='195.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='159.20' cy='185.20' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='178.08' cy='161.16' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='148.61' cy='173.86' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='138.15' cy='199.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='162.55' cy='151.39' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<polyline points='175.59,153.40 174.57,153.27 173.54,153.15 172.52,153.06 171.50,152.97 170.47,152.91 169.45,152.86 168.43,152.82 167.40,152.81 166.38,152.81 165.35,152.83 164.33,152.86 163.31,152.92 162.28,152.99 161.26,153.09 160.24,153.21 159.21,153.36 158.96,153.41 158.19,153.54 157.17,153.75 156.14,153.98 155.12,154.26 154.09,154.57 153.66,154.72 153.07,154.93 152.05,155.34 151.02,155.80 150.56,156.04 150.00,156.33 148.98,156.92 148.32,157.35 147.95,157.60 146.93,158.37 146.58,158.67 145.90,159.26 145.16,159.98 144.88,160.28 143.99,161.30 143.86,161.46 143.00,162.61 142.83,162.86 142.16,163.93 141.81,164.54 141.43,165.24 140.81,166.56 140.79,166.61 140.27,167.87 139.81,169.19 139.76,169.35 139.42,170.50 139.09,171.82 138.80,173.13 138.74,173.50 138.57,174.45 138.39,175.76 138.24,177.08 138.13,178.40 138.06,179.71 138.02,181.03 138.02,182.34 138.05,183.66 138.10,184.97 138.18,186.29 138.30,187.60 138.44,188.92 138.61,190.23 138.74,191.12 138.80,191.55 139.03,192.86 139.29,194.18 139.57,195.49 139.76,196.29 139.89,196.81 140.24,198.12 140.63,199.44 140.79,199.94 141.06,200.75 141.52,202.07 141.81,202.82 142.04,203.38 142.60,204.70 142.83,205.22 143.22,206.02 143.86,207.25 143.90,207.33 144.67,208.65 144.88,209.00 145.52,209.96 145.90,210.51 146.49,211.28 146.93,211.83 147.61,212.59 147.95,212.97 148.91,213.91 148.98,213.97 150.00,214.83 150.53,215.22 151.02,215.58 152.05,216.21 152.67,216.54 153.07,216.74 154.09,217.19 155.12,217.54 156.14,217.81 156.35,217.85 157.17,218.01 158.19,218.14 159.21,218.20 160.24,218.20 161.26,218.13 162.28,218.01 163.16,217.85 163.31,217.83 164.33,217.60 165.35,217.32 166.38,216.99 167.40,216.61 167.57,216.54 168.43,216.19 169.45,215.72 170.44,215.22 170.47,215.21 171.50,214.66 172.52,214.06 172.77,213.91 173.54,213.43 174.57,212.76 174.80,212.59 175.59,212.04 176.62,211.29 176.63,211.28 177.64,210.50 178.30,209.96 178.66,209.67 179.69,208.79 179.85,208.65 180.71,207.88 181.31,207.33 181.73,206.93 182.68,206.02 182.76,205.93 183.78,204.90 183.97,204.70 184.80,203.81 185.20,203.38 185.83,202.68 186.36,202.07 186.85,201.49 187.47,200.75 187.88,200.25 188.52,199.44 188.90,198.95 189.52,198.12 189.92,197.57 190.47,196.81 190.95,196.12 191.38,195.49 191.97,194.58 192.23,194.18 192.99,192.94 193.04,192.86 193.80,191.55 194.02,191.15 194.52,190.23 195.04,189.19 195.18,188.92 195.80,187.60 196.07,186.99 196.37,186.29 196.89,184.97 197.09,184.41 197.36,183.66 197.78,182.34 198.11,181.12 198.14,181.03 198.45,179.71 198.70,178.40 198.88,177.08 199.01,175.76 199.06,174.45 199.05,173.13 198.95,171.82 198.77,170.50 198.50,169.19 198.13,167.87 198.11,167.83 197.64,166.56 197.09,165.37 197.03,165.24 196.27,163.93 196.07,163.64 195.33,162.61 195.04,162.27 194.18,161.30 194.02,161.13 192.99,160.18 192.78,159.98 191.97,159.35 191.04,158.67 190.95,158.60 189.92,157.96 188.90,157.38 188.86,157.35 187.88,156.86 186.85,156.39 186.01,156.04 185.83,155.96 184.80,155.58 183.78,155.24 182.76,154.92 182.08,154.72 181.73,154.63 180.71,154.37 179.69,154.14 178.66,153.92 177.64,153.73 176.62,153.56 175.60,153.41 175.59,153.40 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='31.30' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjYwLjg3fDQ4NC45NXw0MC4zNnwzMjguMjc='>
+    <rect x='260.87' y='40.36' width='224.09' height='287.90' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjYwLjg3fDQ4NC45NXw0MC4zNnwzMjguMjc=)'>
+<rect x='260.87' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='260.87,279.49 484.95,279.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,208.11 484.95,208.11 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,136.73 484.95,136.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,65.34 484.95,65.34 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='298.83,328.27 298.83,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='354.39,328.27 354.39,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='409.95,328.27 409.95,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='465.51,328.27 465.51,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,315.18 484.95,315.18 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,243.80 484.95,243.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,172.42 484.95,172.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='260.87,101.04 484.95,101.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='271.05,328.27 271.05,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='326.61,328.27 326.61,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='382.17,328.27 382.17,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.73,328.27 437.73,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<circle cx='422.27' cy='97.10' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='418.04' cy='81.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='361.29' cy='199.53' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='362.53' cy='163.21' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='406.30' cy='153.56' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='351.38' cy='198.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='417.81' cy='140.60' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='340.07' cy='229.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='392.23' cy='145.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='419.30' cy='146.65' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='400.58' cy='116.83' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='364.34' cy='220.23' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='396.50' cy='135.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='330.12' cy='211.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='315.01' cy='249.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='389.61' cy='143.00' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='420.15' cy='133.96' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='401.65' cy='152.23' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='394.12' cy='141.12' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='367.88' cy='163.03' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='350.22' cy='206.89' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='318.20' cy='246.45' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='393.24' cy='116.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='379.40' cy='167.23' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='388.59' cy='124.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='333.98' cy='245.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='430.14' cy='93.65' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='348.42' cy='191.60' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='368.73' cy='154.26' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='402.93' cy='136.97' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='397.44' cy='147.76' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='345.07' cy='212.99' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='413.02' cy='110.52' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='416.75' cy='129.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='337.02' cy='228.40' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='365.45' cy='128.07' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='428.73' cy='132.88' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='336.50' cy='204.30' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='336.01' cy='247.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='360.50' cy='170.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='404.89' cy='138.02' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='362.26' cy='198.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='354.17' cy='161.18' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='333.79' cy='220.93' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='354.53' cy='231.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='321.25' cy='213.56' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='467.07' cy='97.16' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='360.10' cy='187.89' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='378.34' cy='141.16' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='366.77' cy='144.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='331.77' cy='195.63' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='353.91' cy='248.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='346.19' cy='190.07' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='427.53' cy='134.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='355.25' cy='182.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='433.12' cy='113.03' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='413.93' cy='130.54' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='422.78' cy='105.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='347.12' cy='187.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='390.73' cy='138.06' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='402.57' cy='102.69' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='400.02' cy='134.27' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='427.10' cy='141.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='412.76' cy='119.88' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='415.18' cy='120.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='357.83' cy='188.91' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='354.40' cy='174.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='335.92' cy='232.96' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='395.18' cy='143.02' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='328.64' cy='234.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='346.39' cy='170.59' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='337.45' cy='203.42' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='339.24' cy='174.78' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='393.70' cy='115.69' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='357.17' cy='179.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='362.96' cy='227.19' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='353.74' cy='187.41' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='355.11' cy='150.98' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='344.78' cy='185.88' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='411.19' cy='140.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='401.76' cy='117.54' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='434.03' cy='93.29' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='441.19' cy='106.79' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='398.05' cy='120.59' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='373.64' cy='135.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='424.00' cy='88.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='368.18' cy='182.76' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='354.09' cy='177.66' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='404.30' cy='137.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='400.34' cy='130.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='387.37' cy='148.42' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='365.28' cy='137.20' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='345.09' cy='199.59' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='433.10' cy='96.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='353.55' cy='220.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='393.71' cy='138.33' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='392.26' cy='121.33' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='410.70' cy='126.44' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='390.61' cy='156.25' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='388.70' cy='110.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='349.23' cy='191.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='355.19' cy='184.16' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='422.31' cy='128.74' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='411.73' cy='137.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='348.88' cy='190.63' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='353.49' cy='228.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='401.93' cy='134.04' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='405.09' cy='104.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='383.67' cy='148.98' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='315.94' cy='231.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='344.66' cy='193.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='388.22' cy='104.31' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='333.14' cy='249.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='414.64' cy='79.43' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='353.82' cy='193.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='403.60' cy='131.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='385.14' cy='110.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='354.30' cy='163.92' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='417.50' cy='83.06' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='435.09' cy='142.15' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='375.12' cy='140.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='387.54' cy='152.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='409.32' cy='162.57' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='412.93' cy='153.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='411.84' cy='165.84' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='402.10' cy='177.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='406.22' cy='152.87' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='382.31' cy='179.43' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='388.30' cy='158.49' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='413.82' cy='176.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='394.34' cy='181.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='373.95' cy='174.01' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='396.27' cy='171.04' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='392.20' cy='184.51' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='393.18' cy='180.53' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='432.77' cy='180.88' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='391.63' cy='165.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='380.58' cy='132.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='376.54' cy='178.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='394.18' cy='198.11' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='418.58' cy='157.43' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='363.86' cy='183.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='395.66' cy='150.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='385.26' cy='193.00' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='371.29' cy='217.42' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='385.76' cy='197.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='360.18' cy='140.24' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='434.89' cy='151.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='401.79' cy='153.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='406.64' cy='159.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='418.50' cy='173.40' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='367.83' cy='181.93' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='423.98' cy='156.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='393.88' cy='152.85' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='369.93' cy='202.88' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='373.78' cy='156.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='374.65' cy='172.70' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='361.36' cy='187.87' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='376.87' cy='179.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='401.99' cy='159.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='349.34' cy='160.49' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='398.82' cy='186.69' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='380.95' cy='203.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='404.15' cy='173.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='367.93' cy='203.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='373.64' cy='186.89' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='387.58' cy='179.33' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='372.70' cy='166.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='398.66' cy='174.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='389.19' cy='176.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='378.11' cy='245.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='373.83' cy='146.45' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='373.16' cy='166.38' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='439.63' cy='149.62' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='379.47' cy='144.39' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='375.77' cy='173.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='417.59' cy='152.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='375.30' cy='178.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='385.43' cy='177.64' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='377.56' cy='205.55' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='413.45' cy='146.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='369.36' cy='180.99' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='393.39' cy='157.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='391.60' cy='162.47' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='400.40' cy='169.80' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='394.18' cy='177.57' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='389.64' cy='163.46' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='360.00' cy='164.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='400.60' cy='184.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='412.80' cy='152.10' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='407.03' cy='185.32' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='381.07' cy='157.18' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='373.44' cy='210.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='417.93' cy='174.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='364.99' cy='236.72' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='371.28' cy='171.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='359.25' cy='209.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='365.05' cy='203.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='381.16' cy='214.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='382.81' cy='146.12' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='363.72' cy='170.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='376.25' cy='191.93' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='380.42' cy='198.53' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='400.67' cy='191.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='405.50' cy='176.80' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='394.11' cy='161.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='388.84' cy='188.44' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='403.84' cy='157.50' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='441.72' cy='150.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='386.43' cy='171.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='365.40' cy='175.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='383.72' cy='192.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='370.71' cy='189.94' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='386.13' cy='158.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='391.82' cy='173.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='423.28' cy='157.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='397.60' cy='166.51' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='369.51' cy='181.80' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='403.75' cy='166.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='379.51' cy='214.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='431.09' cy='159.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='371.44' cy='171.11' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='367.90' cy='204.74' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='411.87' cy='169.55' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='396.64' cy='190.25' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='377.55' cy='204.25' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='412.15' cy='148.91' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='414.35' cy='148.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='394.34' cy='144.30' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='424.38' cy='156.46' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='376.75' cy='183.60' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='394.72' cy='188.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='371.32' cy='166.64' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='395.68' cy='201.02' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='432.02' cy='162.07' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='387.97' cy='173.52' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='405.03' cy='161.24' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='384.77' cy='186.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='378.60' cy='178.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='403.48' cy='181.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='411.84' cy='153.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='417.80' cy='164.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='404.32' cy='153.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='399.75' cy='208.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='407.68' cy='195.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='388.77' cy='185.20' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='407.65' cy='161.16' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='378.17' cy='173.86' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='367.72' cy='199.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='392.12' cy='151.39' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<polyline points='442.01,144.01 440.99,144.01 439.96,144.03 438.94,144.06 437.92,144.09 436.89,144.13 435.87,144.18 435.49,144.20 434.84,144.23 433.82,144.28 432.80,144.34 431.77,144.40 430.75,144.46 429.73,144.52 428.70,144.58 427.68,144.64 426.66,144.71 425.63,144.77 424.61,144.84 423.58,144.92 422.56,144.99 421.54,145.07 420.51,145.15 419.49,145.24 418.47,145.34 417.44,145.44 416.67,145.51 416.42,145.54 415.39,145.65 414.37,145.77 413.35,145.88 412.32,146.01 411.30,146.14 410.28,146.27 409.25,146.40 408.23,146.54 407.20,146.68 406.18,146.82 406.08,146.83 405.16,146.95 404.13,147.09 403.11,147.23 402.09,147.36 401.06,147.48 400.04,147.60 399.02,147.72 397.99,147.83 396.97,147.93 395.94,148.03 394.92,148.12 394.59,148.14 393.90,148.20 392.87,148.28 391.85,148.36 390.83,148.43 389.80,148.50 388.78,148.58 387.75,148.66 386.73,148.74 385.71,148.83 384.68,148.94 383.66,149.06 382.64,149.20 381.61,149.37 381.13,149.46 380.59,149.56 379.57,149.79 378.54,150.06 377.52,150.37 376.49,150.74 376.40,150.78 375.47,151.16 374.45,151.65 373.66,152.09 373.42,152.23 372.40,152.89 371.71,153.41 371.38,153.67 370.35,154.57 370.20,154.72 369.33,155.63 368.98,156.04 368.30,156.88 367.97,157.35 367.28,158.38 367.10,158.67 366.37,159.98 366.26,160.20 365.74,161.30 365.23,162.48 365.18,162.61 364.70,163.93 364.28,165.24 364.21,165.49 363.91,166.56 363.59,167.87 363.30,169.19 363.19,169.78 363.05,170.50 362.83,171.82 362.63,173.13 362.46,174.45 362.31,175.76 362.18,177.08 362.16,177.22 362.05,178.40 361.95,179.71 361.86,181.03 361.77,182.34 361.70,183.66 361.64,184.97 361.59,186.29 361.54,187.60 361.50,188.92 361.47,190.23 361.44,191.55 361.43,192.86 361.42,194.18 361.42,195.49 361.44,196.81 361.46,198.12 361.50,199.44 361.54,200.75 361.61,202.07 361.69,203.38 361.78,204.70 361.89,206.02 362.03,207.33 362.16,208.50 362.18,208.65 362.35,209.96 362.55,211.28 362.76,212.59 363.00,213.91 363.19,214.85 363.26,215.22 363.54,216.54 363.85,217.85 364.17,219.17 364.21,219.31 364.52,220.48 364.89,221.80 365.23,222.98 365.27,223.11 365.68,224.43 366.10,225.74 366.26,226.24 366.53,227.06 366.98,228.37 367.28,229.25 367.44,229.69 367.91,231.00 368.30,232.10 368.39,232.32 368.88,233.63 369.33,234.84 369.37,234.95 369.88,236.27 370.35,237.50 370.39,237.58 370.91,238.90 371.38,240.08 371.43,240.21 371.98,241.53 372.40,242.56 372.52,242.84 373.09,244.16 373.42,244.93 373.68,245.47 374.29,246.79 374.45,247.14 374.94,248.10 375.47,249.16 375.62,249.42 376.36,250.73 376.49,250.97 377.19,252.05 377.52,252.56 378.12,253.36 378.54,253.93 379.21,254.68 379.57,255.08 380.55,255.99 380.59,256.03 381.61,256.81 382.47,257.31 382.64,257.41 383.66,257.86 384.68,258.17 385.71,258.34 386.73,258.39 387.75,258.32 388.78,258.13 389.80,257.84 390.83,257.44 391.10,257.31 391.85,256.95 392.87,256.35 393.39,255.99 393.90,255.65 394.92,254.86 395.13,254.68 395.94,253.97 396.58,253.36 396.97,252.99 397.86,252.05 397.99,251.91 399.02,250.74 399.02,250.73 400.04,249.49 400.09,249.42 401.06,248.15 401.10,248.10 402.05,246.79 402.09,246.73 402.95,245.47 403.11,245.24 403.83,244.16 404.13,243.69 404.67,242.84 405.16,242.07 405.49,241.53 406.18,240.40 406.29,240.21 407.08,238.90 407.20,238.69 407.86,237.58 408.23,236.96 408.64,236.27 409.25,235.21 409.40,234.95 410.17,233.63 410.28,233.46 410.95,232.32 411.30,231.73 411.73,231.00 412.32,230.02 412.53,229.69 413.33,228.37 413.35,228.35 414.17,227.06 414.37,226.75 415.04,225.74 415.39,225.21 415.94,224.43 416.42,223.75 416.88,223.11 417.44,222.36 417.87,221.80 418.47,221.06 418.94,220.48 419.49,219.83 420.07,219.17 420.51,218.68 421.30,217.85 421.54,217.61 422.56,216.59 422.62,216.54 423.58,215.65 424.07,215.22 424.61,214.76 425.63,213.91 425.63,213.91 426.66,213.11 427.33,212.59 427.68,212.34 428.70,211.60 429.15,211.28 429.73,210.88 430.75,210.18 431.07,209.96 431.77,209.50 432.80,208.82 433.06,208.65 433.82,208.16 434.84,207.48 435.08,207.33 435.87,206.82 436.89,206.14 437.07,206.02 437.92,205.46 438.94,204.76 439.02,204.70 439.96,204.05 440.89,203.38 440.99,203.31 442.01,202.57 442.66,202.07 443.03,201.79 444.06,200.98 444.34,200.75 445.08,200.15 445.91,199.44 446.11,199.28 447.13,198.37 447.39,198.12 448.15,197.42 448.78,196.81 449.18,196.42 450.08,195.49 450.20,195.37 451.22,194.27 451.30,194.18 452.25,193.10 452.45,192.86 453.27,191.87 453.53,191.55 454.29,190.56 454.54,190.23 455.32,189.15 455.49,188.92 456.34,187.65 456.37,187.60 457.21,186.29 457.37,186.03 457.99,184.97 458.39,184.26 458.72,183.66 459.40,182.34 459.41,182.32 460.04,181.03 460.44,180.13 460.62,179.71 461.17,178.40 461.46,177.61 461.66,177.08 462.11,175.76 462.48,174.55 462.52,174.45 462.88,173.13 463.20,171.82 463.47,170.50 463.51,170.26 463.69,169.19 463.87,167.87 464.00,166.56 464.07,165.24 464.09,163.93 464.06,162.61 463.96,161.30 463.80,159.98 463.56,158.67 463.51,158.44 463.25,157.35 462.85,156.04 462.48,155.07 462.35,154.72 461.74,153.41 461.46,152.91 460.98,152.09 460.44,151.29 460.06,150.78 459.41,150.00 458.92,149.46 458.39,148.94 457.48,148.14 457.37,148.06 456.34,147.32 455.57,146.83 455.32,146.69 454.29,146.16 453.27,145.71 452.76,145.51 452.25,145.33 451.22,145.02 450.20,144.76 449.18,144.55 448.15,144.39 447.13,144.25 446.58,144.20 446.11,144.16 445.08,144.09 444.06,144.04 443.03,144.01 442.01,144.01 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='260.87' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkwLjQzfDcxNC41Mnw0MC4zNnwzMjguMjc='>
+    <rect x='490.43' y='40.36' width='224.09' height='287.90' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkwLjQzfDcxNC41Mnw0MC4zNnwzMjguMjc=)'>
+<rect x='490.43' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='490.43,279.49 714.52,279.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,208.11 714.52,208.11 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,136.73 714.52,136.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,65.34 714.52,65.34 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='528.40,328.27 528.40,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='583.96,328.27 583.96,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='639.52,328.27 639.52,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='695.08,328.27 695.08,40.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,315.18 714.52,315.18 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,243.80 714.52,243.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,172.42 714.52,172.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.43,101.04 714.52,101.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='500.62,328.27 500.62,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='556.18,328.27 556.18,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='611.74,328.27 611.74,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='667.30,328.27 667.30,40.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<circle cx='651.83' cy='97.10' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='647.61' cy='81.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='590.86' cy='199.53' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='592.09' cy='163.21' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='635.86' cy='153.56' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='580.94' cy='198.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='647.38' cy='140.60' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='569.64' cy='229.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='621.79' cy='145.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='648.86' cy='146.65' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='630.15' cy='116.83' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='593.91' cy='220.23' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='626.07' cy='135.86' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='559.68' cy='211.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='544.58' cy='249.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='619.18' cy='143.00' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='649.72' cy='133.96' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='631.22' cy='152.23' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='623.68' cy='141.12' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='597.44' cy='163.03' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='579.79' cy='206.89' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='547.76' cy='246.45' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='622.81' cy='116.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='608.96' cy='167.23' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='618.16' cy='124.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='563.55' cy='245.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='659.71' cy='93.65' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='577.99' cy='191.60' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='598.29' cy='154.26' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='632.50' cy='136.97' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='627.01' cy='147.76' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='574.63' cy='212.99' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='642.59' cy='110.52' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='646.32' cy='129.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='566.59' cy='228.40' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='595.02' cy='128.07' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='658.30' cy='132.88' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='566.07' cy='204.30' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='565.58' cy='247.58' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='590.07' cy='170.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='634.45' cy='138.02' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='591.83' cy='198.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.74' cy='161.18' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='563.36' cy='220.93' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='584.10' cy='231.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='550.82' cy='213.56' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='696.64' cy='97.16' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='589.66' cy='187.89' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='607.91' cy='141.16' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='596.33' cy='144.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='561.33' cy='195.63' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.48' cy='248.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='575.76' cy='190.07' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='657.10' cy='134.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='584.82' cy='182.64' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='662.69' cy='113.03' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='643.49' cy='130.54' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='652.35' cy='105.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='576.68' cy='187.80' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='620.30' cy='138.06' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='632.14' cy='102.69' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='629.58' cy='134.27' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='656.67' cy='141.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='642.32' cy='119.88' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='644.75' cy='120.05' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='587.40' cy='188.91' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.96' cy='174.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='565.48' cy='232.96' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='624.75' cy='143.02' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='558.21' cy='234.46' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='575.95' cy='170.59' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='567.02' cy='203.42' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='568.81' cy='174.78' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='623.26' cy='115.69' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='586.73' cy='179.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='592.53' cy='227.19' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.31' cy='187.41' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='584.67' cy='150.98' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='574.34' cy='185.88' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='640.76' cy='140.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='631.32' cy='117.54' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='663.60' cy='93.29' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='670.75' cy='106.79' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='627.61' cy='120.59' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='603.20' cy='135.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='653.56' cy='88.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='597.75' cy='182.76' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.65' cy='177.66' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='633.86' cy='137.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='629.90' cy='130.73' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='616.94' cy='148.42' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='594.85' cy='137.20' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='574.66' cy='199.59' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='662.67' cy='96.50' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.11' cy='220.84' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='623.27' cy='138.33' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='621.83' cy='121.33' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='640.27' cy='126.44' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='620.17' cy='156.25' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='618.27' cy='110.01' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='578.80' cy='191.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='584.76' cy='184.16' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='651.88' cy='128.74' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='641.30' cy='137.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='578.44' cy='190.63' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.05' cy='228.32' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='631.49' cy='134.04' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='634.66' cy='104.39' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='613.23' cy='148.98' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='545.50' cy='231.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='574.23' cy='193.47' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='617.79' cy='104.31' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='562.70' cy='249.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='644.20' cy='79.43' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.39' cy='193.81' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='633.16' cy='131.36' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='614.71' cy='110.35' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='583.86' cy='163.92' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='647.07' cy='83.06' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='664.66' cy='142.15' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='604.69' cy='140.34' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='617.10' cy='152.85' r='1.42' style='stroke-width: 0.71; stroke: #218239; stroke-opacity: 0.75; fill: #218239; fill-opacity: 0.75;' />
+<circle cx='638.88' cy='162.57' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='642.50' cy='153.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='641.41' cy='165.84' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='631.67' cy='177.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='635.78' cy='152.87' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='611.87' cy='179.43' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='617.86' cy='158.49' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='643.38' cy='176.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='623.91' cy='181.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='603.52' cy='174.01' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='625.84' cy='171.04' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='621.77' cy='184.51' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='622.75' cy='180.53' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='662.33' cy='180.88' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='621.20' cy='165.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='610.15' cy='132.34' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='606.10' cy='178.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='623.75' cy='198.11' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='648.14' cy='157.43' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='593.42' cy='183.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='625.23' cy='150.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='614.83' cy='193.00' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='600.86' cy='217.42' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='615.33' cy='197.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='589.74' cy='140.24' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='664.46' cy='151.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='631.35' cy='153.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='636.21' cy='159.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='648.07' cy='173.40' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='597.40' cy='181.93' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='653.54' cy='156.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='623.44' cy='152.85' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='599.50' cy='202.88' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='603.35' cy='156.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='604.22' cy='172.70' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='590.92' cy='187.87' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='606.44' cy='179.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='631.55' cy='159.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='578.91' cy='160.49' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='628.39' cy='186.69' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='610.51' cy='203.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='633.72' cy='173.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='597.50' cy='203.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='603.21' cy='186.89' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='617.15' cy='179.33' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='602.27' cy='166.21' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='628.23' cy='174.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='618.76' cy='176.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='607.67' cy='245.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='603.40' cy='146.45' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='602.72' cy='166.38' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='669.20' cy='149.62' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='609.04' cy='144.39' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='605.33' cy='173.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='647.16' cy='152.48' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='604.87' cy='178.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='615.00' cy='177.64' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='607.13' cy='205.55' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='643.01' cy='146.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='598.92' cy='180.99' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='622.95' cy='157.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='621.16' cy='162.47' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='629.96' cy='169.80' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='623.74' cy='177.57' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='619.20' cy='163.46' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='589.56' cy='164.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='630.17' cy='184.65' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='642.36' cy='152.10' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='636.59' cy='185.32' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='610.63' cy='157.18' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='603.00' cy='210.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='647.49' cy='174.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='594.55' cy='236.72' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='600.85' cy='171.05' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='588.82' cy='209.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='594.61' cy='203.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='610.72' cy='214.56' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='612.37' cy='146.12' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='593.29' cy='170.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='605.82' cy='191.93' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='609.99' cy='198.53' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='630.24' cy='191.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='635.06' cy='176.80' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='623.67' cy='161.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='618.40' cy='188.44' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='633.40' cy='157.50' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='671.29' cy='150.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='615.99' cy='171.08' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='594.97' cy='175.81' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='613.29' cy='192.71' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='600.28' cy='189.94' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='615.69' cy='158.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='621.38' cy='173.58' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='652.84' cy='157.37' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='627.16' cy='166.51' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='599.07' cy='181.80' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='633.32' cy='166.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='609.08' cy='214.96' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='660.66' cy='159.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='601.00' cy='171.11' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='597.47' cy='204.74' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='641.44' cy='169.55' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='626.21' cy='190.25' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='607.12' cy='204.25' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='641.72' cy='148.91' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='643.92' cy='148.66' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='623.91' cy='144.30' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='653.95' cy='156.46' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='606.32' cy='183.60' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='624.29' cy='188.76' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='600.88' cy='166.64' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='625.25' cy='201.02' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='661.58' cy='162.07' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='617.54' cy='173.52' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='634.59' cy='161.24' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='614.34' cy='186.67' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='608.17' cy='178.35' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='633.05' cy='181.97' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='641.41' cy='153.73' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='647.36' cy='164.82' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='633.89' cy='153.61' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='629.31' cy='208.14' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='637.25' cy='195.59' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='618.33' cy='185.20' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='637.21' cy='161.16' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='607.74' cy='173.86' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='597.28' cy='199.17' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<circle cx='621.68' cy='151.39' r='1.42' style='stroke-width: 0.71; stroke: #D4AD42; stroke-opacity: 0.75; fill: #D4AD42; fill-opacity: 0.75;' />
+<polyline points='622.68,53.45 622.44,53.48 621.42,53.65 620.39,53.84 619.37,54.06 618.34,54.31 617.32,54.58 616.70,54.76 616.30,54.87 615.27,55.18 614.25,55.50 613.23,55.85 612.58,56.08 612.20,56.21 611.18,56.56 610.15,56.93 609.13,57.31 608.91,57.39 608.11,57.68 607.08,58.04 606.06,58.41 605.19,58.71 605.04,58.76 604.01,59.09 602.99,59.42 601.97,59.74 601.01,60.02 600.94,60.04 599.92,60.33 598.89,60.61 597.87,60.88 596.85,61.16 596.22,61.34 595.82,61.45 594.80,61.73 593.78,62.02 592.75,62.34 591.84,62.65 591.73,62.69 590.70,63.05 589.68,63.46 588.66,63.92 588.55,63.97 587.63,64.41 586.61,64.98 586.13,65.28 585.59,65.63 584.56,66.37 584.28,66.60 583.54,67.23 582.83,67.92 582.52,68.25 581.69,69.23 581.49,69.49 580.79,70.55 580.47,71.11 580.09,71.86 579.55,73.18 579.44,73.52 579.16,74.49 578.90,75.81 578.76,77.12 578.71,78.44 578.75,79.75 578.87,81.07 579.05,82.38 579.30,83.70 579.44,84.30 579.60,85.01 579.95,86.33 580.34,87.64 580.47,88.03 580.76,88.96 581.21,90.27 581.49,91.04 581.68,91.59 582.18,92.90 582.52,93.77 582.69,94.22 583.21,95.54 583.54,96.34 583.74,96.85 584.28,98.17 584.56,98.83 584.83,99.48 585.38,100.80 585.59,101.29 585.94,102.11 586.48,103.43 586.61,103.74 587.03,104.74 587.57,106.06 587.63,106.21 588.12,107.37 588.64,108.69 588.66,108.73 589.18,110.00 589.68,111.32 589.68,111.33 590.20,112.63 590.67,113.95 590.70,114.04 591.17,115.26 591.62,116.58 591.73,116.93 592.07,117.89 592.49,119.21 592.75,120.12 592.89,120.52 593.28,121.84 593.61,123.16 593.78,123.93 593.92,124.47 594.22,125.79 594.45,127.10 594.63,128.42 594.76,129.73 594.80,130.50 594.84,131.05 594.85,132.36 594.80,133.25 594.78,133.68 594.63,134.99 594.36,136.31 593.93,137.62 593.78,137.96 593.37,138.94 592.75,140.00 592.61,140.25 591.73,141.52 591.70,141.57 590.70,142.83 590.66,142.88 589.68,144.03 589.55,144.20 588.66,145.21 588.41,145.51 587.63,146.40 587.28,146.83 586.61,147.64 586.22,148.14 585.59,148.99 585.26,149.46 584.56,150.50 584.39,150.78 583.65,152.09 583.54,152.30 583.03,153.41 582.52,154.64 582.48,154.72 582.08,156.04 581.73,157.35 581.49,158.52 581.46,158.67 581.28,159.98 581.15,161.30 581.04,162.61 580.93,163.93 580.76,165.24 580.47,166.33 580.40,166.56 579.62,167.87 579.44,168.03 578.42,168.86 577.94,169.19 577.40,169.45 576.37,169.92 575.35,170.34 574.96,170.50 574.33,170.71 573.30,171.05 572.28,171.37 571.25,171.68 570.82,171.82 570.23,171.98 569.21,172.26 568.18,172.52 567.16,172.79 566.14,173.05 565.80,173.13 565.11,173.30 564.09,173.55 563.07,173.79 562.04,174.02 561.02,174.26 560.21,174.45 559.99,174.50 558.97,174.74 557.95,174.97 556.92,175.20 555.90,175.43 554.88,175.68 554.50,175.76 553.85,175.92 552.83,176.17 551.80,176.42 550.78,176.67 549.76,176.94 549.23,177.08 548.73,177.22 547.71,177.51 546.69,177.81 545.66,178.13 544.84,178.40 544.64,178.47 543.61,178.83 542.59,179.21 541.57,179.63 541.37,179.71 540.54,180.09 539.52,180.59 538.69,181.03 538.50,181.14 537.47,181.77 536.60,182.34 536.45,182.46 535.43,183.26 534.95,183.66 534.40,184.19 533.63,184.97 533.38,185.28 532.56,186.29 532.35,186.60 531.69,187.60 531.33,188.27 530.98,188.92 530.40,190.23 530.31,190.50 529.92,191.55 529.55,192.86 529.28,194.08 529.26,194.18 529.03,195.49 528.87,196.81 528.76,198.12 528.71,199.44 528.71,200.75 528.74,202.07 528.81,203.38 528.92,204.70 529.06,206.02 529.22,207.33 529.28,207.76 529.40,208.65 529.59,209.96 529.80,211.28 530.02,212.59 530.24,213.91 530.31,214.30 530.45,215.22 530.66,216.54 530.85,217.85 531.04,219.17 531.20,220.48 531.33,221.63 531.35,221.80 531.47,223.11 531.56,224.43 531.64,225.74 531.71,227.06 531.75,228.37 531.79,229.69 531.82,231.00 531.84,232.32 531.87,233.63 531.90,234.95 531.93,236.27 531.98,237.58 532.04,238.90 532.12,240.21 532.21,241.53 532.33,242.84 532.35,243.09 532.46,244.16 532.61,245.47 532.79,246.79 532.99,248.10 533.23,249.42 533.38,250.15 533.49,250.73 533.77,252.05 534.09,253.36 534.40,254.50 534.45,254.68 534.82,255.99 535.24,257.31 535.43,257.84 535.69,258.62 536.18,259.94 536.45,260.61 536.71,261.25 537.28,262.57 537.47,262.99 537.89,263.89 538.50,265.09 538.55,265.20 539.26,266.52 539.52,266.96 540.03,267.83 540.54,268.65 540.86,269.15 541.57,270.18 541.77,270.46 542.59,271.57 542.75,271.78 543.61,272.84 543.83,273.09 544.64,273.99 545.04,274.41 545.66,275.04 546.40,275.72 546.69,275.98 547.71,276.83 547.98,277.04 548.73,277.60 549.76,278.26 549.93,278.35 550.78,278.84 551.80,279.32 552.73,279.67 552.83,279.71 553.85,280.02 554.88,280.22 555.90,280.33 556.92,280.33 557.95,280.22 558.97,279.99 559.90,279.67 559.99,279.64 561.02,279.19 562.04,278.59 562.36,278.35 563.07,277.87 564.05,277.04 564.09,277.01 565.11,276.04 565.39,275.72 566.14,274.95 566.57,274.41 567.16,273.74 567.65,273.09 568.18,272.44 568.65,271.78 569.21,271.04 569.60,270.46 570.23,269.58 570.51,269.15 571.25,268.06 571.40,267.83 572.26,266.52 572.28,266.49 573.10,265.20 573.30,264.91 573.94,263.89 574.33,263.31 574.78,262.57 575.35,261.69 575.61,261.25 576.37,260.06 576.44,259.94 577.27,258.62 577.40,258.43 578.10,257.31 578.42,256.81 578.94,255.99 579.44,255.21 579.78,254.68 580.47,253.62 580.63,253.36 581.48,252.05 581.49,252.04 582.34,250.73 582.52,250.48 583.22,249.42 583.54,248.94 584.11,248.10 584.56,247.43 585.01,246.79 585.59,245.96 585.94,245.47 586.61,244.52 586.88,244.16 587.63,243.11 587.85,242.84 588.66,241.75 588.84,241.53 589.68,240.43 589.86,240.21 590.70,239.15 590.92,238.90 591.73,237.90 592.02,237.58 592.75,236.69 593.15,236.27 593.78,235.51 594.30,234.95 594.80,234.34 595.44,233.63 595.82,233.15 596.54,232.32 596.85,231.90 597.55,231.00 597.87,230.50 598.41,229.69 598.89,228.76 599.10,228.37 599.56,227.06 599.81,225.74 599.80,224.43 599.52,223.11 598.94,221.80 598.89,221.72 597.87,220.53 597.80,220.48 596.85,219.87 595.82,219.51 594.80,219.36 593.78,219.37 592.75,219.48 591.73,219.66 590.70,219.87 589.68,220.08 588.66,220.27 587.63,220.42 586.98,220.48 586.61,220.51 585.59,220.53 584.60,220.48 584.56,220.48 583.54,220.31 582.52,220.03 581.49,219.61 580.72,219.17 580.47,218.96 579.47,217.85 579.44,217.80 579.02,216.54 579.06,215.22 579.44,213.91 579.44,213.91 580.16,212.59 580.47,212.15 581.10,211.28 581.49,210.81 582.22,209.96 582.52,209.64 583.46,208.65 583.54,208.56 584.56,207.54 584.77,207.33 585.59,206.52 586.08,206.02 586.61,205.46 587.32,204.70 587.63,204.33 588.44,203.38 588.66,203.08 589.41,202.07 589.68,201.63 590.23,200.75 590.70,199.78 590.88,199.44 591.38,198.12 591.72,196.81 591.73,196.75 591.94,195.49 592.01,194.18 591.94,192.86 591.73,191.56 591.73,191.55 591.44,190.23 591.03,188.92 590.70,188.07 590.55,187.60 590.03,186.29 589.68,185.51 589.47,184.97 588.89,183.66 588.66,183.13 588.32,182.34 587.76,181.03 587.63,180.73 587.23,179.71 586.71,178.40 586.61,178.10 586.25,177.08 585.84,175.76 585.59,174.74 585.51,174.45 585.29,173.13 585.25,171.82 585.56,170.50 585.59,170.45 586.43,169.19 586.61,169.03 587.63,168.17 588.00,167.87 588.66,167.44 589.68,166.75 589.95,166.56 590.70,166.06 591.73,165.33 591.84,165.24 592.75,164.54 593.47,163.93 593.78,163.66 594.80,162.64 594.83,162.61 595.82,161.42 595.92,161.30 596.80,159.98 596.85,159.90 597.53,158.67 597.87,157.91 598.12,157.35 598.62,156.04 598.89,155.17 599.04,154.72 599.42,153.41 599.76,152.09 599.92,151.39 600.07,150.78 600.39,149.46 600.69,148.14 600.94,147.12 601.02,146.83 601.38,145.51 601.77,144.20 601.97,143.57 602.20,142.88 602.66,141.57 602.99,140.63 603.13,140.25 603.57,138.94 603.97,137.62 604.01,137.47 604.30,136.31 604.56,134.99 604.76,133.68 604.91,132.36 605.04,131.05 605.04,131.04 605.14,129.73 605.24,128.42 605.34,127.10 605.47,125.79 605.61,124.47 605.78,123.16 605.99,121.84 606.06,121.51 606.26,120.52 606.59,119.21 606.98,117.89 607.08,117.61 607.51,116.58 608.11,115.41 608.20,115.26 609.13,114.14 609.41,113.95 610.15,113.53 611.18,113.43 612.20,113.78 612.43,113.95 613.23,114.57 613.82,115.26 614.25,115.78 614.75,116.58 615.27,117.46 615.49,117.89 616.08,119.21 616.30,119.73 616.58,120.52 617.01,121.84 617.32,122.88 617.39,123.16 617.69,124.47 617.94,125.79 618.13,127.10 618.28,128.42 618.34,129.51 618.36,129.73 618.37,131.05 618.34,131.81 618.32,132.36 618.20,133.68 618.02,134.99 617.80,136.31 617.56,137.62 617.33,138.94 617.32,138.98 617.15,140.25 617.08,141.57 617.15,142.88 617.32,143.74 617.42,144.20 617.94,145.51 618.34,146.17 618.86,146.83 619.37,147.30 620.39,147.92 621.13,148.14 621.42,148.22 622.44,148.24 623.00,148.14 623.46,148.06 624.49,147.67 625.51,147.11 625.90,146.83 626.53,146.40 627.56,145.57 627.61,145.51 628.58,144.72 629.18,144.20 629.61,143.89 630.63,143.14 630.99,142.88 631.65,142.51 632.68,141.97 633.57,141.57 633.70,141.52 634.72,141.21 635.75,140.99 636.77,140.86 637.79,140.82 638.82,140.89 639.84,141.06 640.87,141.33 641.52,141.57 641.89,141.72 642.91,142.27 643.93,142.88 643.94,142.89 644.96,143.69 645.57,144.20 645.98,144.58 646.99,145.51 647.01,145.53 648.03,146.55 648.33,146.83 649.06,147.53 649.80,148.14 650.08,148.38 651.10,149.10 651.76,149.46 652.13,149.65 653.15,150.08 654.17,150.38 655.20,150.58 656.22,150.70 657.24,150.75 658.27,150.76 659.29,150.71 660.32,150.63 661.34,150.51 662.36,150.36 663.39,150.18 664.41,149.97 665.43,149.73 666.41,149.46 666.46,149.45 667.48,149.14 668.51,148.81 669.53,148.45 670.30,148.14 670.55,148.04 671.58,147.61 672.60,147.15 673.24,146.83 673.62,146.63 674.65,146.09 675.66,145.51 675.67,145.51 676.70,144.88 677.72,144.20 677.73,144.20 678.74,143.48 679.54,142.88 679.77,142.70 680.79,141.88 681.16,141.57 681.81,140.99 682.63,140.25 682.84,140.05 683.86,139.04 683.96,138.94 684.88,137.96 685.20,137.62 685.91,136.80 686.34,136.31 686.93,135.56 687.40,134.99 687.96,134.24 688.39,133.68 688.98,132.82 689.31,132.36 690.00,131.29 690.17,131.05 690.98,129.73 691.03,129.64 691.75,128.42 692.05,127.84 692.47,127.10 693.07,125.90 693.14,125.79 693.78,124.47 694.10,123.74 694.38,123.16 694.93,121.84 695.12,121.33 695.46,120.52 695.94,119.21 696.15,118.58 696.39,117.89 696.81,116.58 697.17,115.29 697.18,115.26 697.53,113.95 697.84,112.63 698.10,111.32 698.19,110.72 698.33,110.00 698.52,108.69 698.66,107.37 698.75,106.06 698.80,104.74 698.79,103.43 698.73,102.11 698.61,100.80 698.43,99.48 698.19,98.29 698.17,98.17 697.86,96.85 697.46,95.54 697.17,94.75 696.98,94.22 696.41,92.90 696.15,92.38 695.74,91.59 695.12,90.53 694.97,90.27 694.10,88.98 694.08,88.96 693.08,87.64 693.07,87.63 692.05,86.44 691.95,86.33 691.03,85.35 690.69,85.01 690.00,84.36 689.27,83.70 688.98,83.44 687.96,82.58 687.71,82.38 686.93,81.77 686.00,81.07 685.91,81.00 684.88,80.26 684.15,79.75 683.86,79.56 682.84,78.87 682.17,78.44 681.81,78.21 680.79,77.56 680.08,77.12 679.77,76.93 678.74,76.29 677.92,75.81 677.72,75.68 676.70,75.06 675.71,74.49 675.67,74.47 674.65,73.84 673.62,73.25 673.51,73.18 672.60,72.62 671.58,72.02 671.32,71.86 670.55,71.39 669.53,70.77 669.16,70.55 668.51,70.13 667.48,69.50 667.04,69.23 666.46,68.86 665.43,68.21 664.95,67.92 664.41,67.56 663.39,66.91 662.89,66.60 662.36,66.26 661.34,65.60 660.84,65.28 660.32,64.95 659.29,64.30 658.77,63.97 658.27,63.65 657.24,63.01 656.66,62.65 656.22,62.38 655.20,61.76 654.48,61.34 654.17,61.16 653.15,60.55 652.18,60.02 652.13,59.99 651.10,59.41 650.08,58.88 649.73,58.71 649.06,58.35 648.03,57.85 647.03,57.39 647.01,57.38 645.98,56.91 644.96,56.47 643.94,56.08 643.94,56.08 642.91,55.68 641.89,55.31 640.87,54.98 640.12,54.76 639.84,54.68 638.82,54.38 637.79,54.12 636.77,53.89 635.75,53.69 634.72,53.51 634.26,53.45 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='490.43' y='40.36' width='224.09' height='287.90' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzEuMzB8MjU1LjM5fDIzLjM0fDQwLjM2'>
+    <rect x='31.30' y='23.34' width='224.09' height='17.03' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzEuMzB8MjU1LjM5fDIzLjM0fDQwLjM2)'>
+<rect x='31.30' y='23.34' width='224.09' height='17.03' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='143.35' y='35.00' text-anchor='middle' style='font-size: 8.80px;fill: #1A1A1A; font-family: "Arial";' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>underfit</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjYwLjg3fDQ4NC45NXwyMy4zNHw0MC4zNg=='>
+    <rect x='260.87' y='23.34' width='224.09' height='17.03' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjYwLjg3fDQ4NC45NXwyMy4zNHw0MC4zNg==)'>
+<rect x='260.87' y='23.34' width='224.09' height='17.03' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='372.91' y='35.00' text-anchor='middle' style='font-size: 8.80px;fill: #1A1A1A; font-family: "Arial";' textLength='41.58px' lengthAdjust='spacingAndGlyphs'>about right</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkwLjQzfDcxNC41MnwyMy4zNHw0MC4zNg=='>
+    <rect x='490.43' y='23.34' width='224.09' height='17.03' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkwLjQzfDcxNC41MnwyMy4zNHw0MC4zNg==)'>
+<rect x='490.43' y='23.34' width='224.09' height='17.03' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='602.48' y='35.00' text-anchor='middle' style='font-size: 8.80px;fill: #1A1A1A; font-family: "Arial";' textLength='23.95px' lengthAdjust='spacingAndGlyphs'>overfit</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHwzNjAuMDA=)'>
+<polyline points='41.49,331.01 41.49,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='97.05,331.01 97.05,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='152.60,331.01 152.60,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='208.16,331.01 208.16,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='41.49' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-6</text>
+<text x='97.05' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='152.60' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='208.16' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<polyline points='271.05,331.01 271.05,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='326.61,331.01 326.61,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='382.17,331.01 382.17,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='437.73,331.01 437.73,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='271.05' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-6</text>
+<text x='326.61' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='382.17' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='437.73' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<polyline points='500.62,331.01 500.62,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='556.18,331.01 556.18,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='611.74,331.01 611.74,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='667.30,331.01 667.30,328.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='500.62' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-6</text>
+<text x='556.18' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='611.74' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='667.30' y='339.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='26.37' y='318.33' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-6</text>
+<text x='26.37' y='246.95' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='26.37' y='175.57' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='26.37' y='104.19' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<polyline points='28.56,315.18 31.30,315.18 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.56,243.80 31.30,243.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.56,172.42 31.30,172.42 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.56,101.04 31.30,101.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='372.91' y='352.09' text-anchor='middle' style='font-size: 11.00px; font-family: "Arial";' textLength='54.41px' lengthAdjust='spacingAndGlyphs'>Predictor A</text>
+<text transform='translate(13.37,184.31) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Arial";' textLength='54.41px' lengthAdjust='spacingAndGlyphs'>Predictor B</text>
+<text x='31.30' y='14.94' style='font-size: 13.20px; font-family: "Arial";' textLength='71.12px' lengthAdjust='spacingAndGlyphs'>Training Set</text>
+</g>
+</svg>

--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -332,11 +332,109 @@ Calibration plot: We bin observations according to predicted probability. In the
 
 ## Dangers of overfitting  {.annotation}
 
-![](https://raw.githubusercontent.com/topepo/2022-nyr-workshop/main/images/tuning-overfitting-train-1.svg)
+```{r overfitting-train}
+#| echo: false
+data(parabolic)
+
+set.seed(15)
+split <- initial_split(parabolic, strata = "class", prop = 1/2)
+
+training_set <- training(split)
+testing_set  <-  testing(split)
+
+data_grid <-
+  crossing(X1 = seq(-6, 5, length = 200),
+           X2 = seq(-6, 5, length = 200))
+
+
+two_class_rec <-
+  recipe(class ~ ., data = parabolic) %>%
+  step_normalize(all_numeric_predictors())
+
+svm_mod <-
+  svm_rbf(cost = tune(), rbf_sigma = 1) %>%
+  set_engine("kernlab") %>%
+  set_mode("classification")
+
+svm_wflow <-
+  workflow() %>%
+  add_recipe(two_class_rec) %>%
+  add_model(svm_mod)
+
+vals <- c("underfit", "about right", "overfit")
+svm_res <-
+  tibble(
+    cost = c(0.005, 0.5, 5000),
+    label = factor(vals, levels = vals),
+    train = NA_real_,
+    test = NA_real_,
+    model = vector(mode = "list", length = 3)
+  )
+
+for (i in 1:nrow(svm_res)) {
+  set.seed(27)
+  tmp_mod <-
+    svm_wflow %>% finalize_workflow(svm_res %>% slice(i) %>% select(cost)) %>%
+    fit(training_set)
+  svm_res$train[i] <-
+    roc_auc_vec(training_set$class,
+                predict(tmp_mod, training_set, type = "prob")$.pred_Class1)
+  svm_res$test[i]  <-
+    roc_auc_vec(testing_set$class,
+                predict(tmp_mod, testing_set, type = "prob")$.pred_Class1)
+  svm_res$model[[i]] <- tmp_mod
+}
+
+
+te_plot <-
+  svm_res %>%
+  mutate(probs = map(model, ~ bind_cols(
+    data_grid, predict(.x, data_grid, type = "prob")
+  ))) %>%
+  dplyr::select(label, probs) %>%
+  unnest(cols = c(probs)) %>%
+  ggplot(aes(x = X1, y = X2)) +
+  geom_point(
+    data = testing_set,
+    aes(col = class),
+    alpha = .75,
+    cex = 1,
+    show.legend = FALSE
+  ) +
+  geom_contour(aes(z = .pred_Class1), breaks = 0.5, col = "black") +
+  facet_wrap( ~ label, nrow = 1) +
+  ggtitle("Test Set") +
+  labs(x = "Predictor A", y = "Predictor B") 
+
+tr_plot <-
+  svm_res %>%
+  mutate(probs = map(model, ~ bind_cols(
+    data_grid, predict(.x, data_grid, type = "prob")
+  ))) %>%
+  dplyr::select(label, probs) %>%
+  unnest(cols = c(probs)) %>%
+  ggplot(aes(x = X1, y = X2)) +
+  geom_point(
+    data = training_set,
+    aes(col = class),
+    alpha = .75,
+    cex = 1,
+    show.legend = FALSE
+  ) +
+  geom_contour(aes(z = .pred_Class1), breaks = 0.5, col = "black") +
+  facet_wrap( ~ label, nrow = 1) +
+  ggtitle("Training Set") +
+  labs(x = "Predictor A", y = "Predictor B")
+
+tr_plot + lims(x = c(-6, 5), y = c(-6, 5))
+```
 
 ## Dangers of overfitting ⚠️
 
-![](https://raw.githubusercontent.com/topepo/2022-nyr-workshop/main/images/tuning-overfitting-test-1.svg)
+```{r overfitting-test}
+#| echo: false
+te_plot + lims(x = c(-6, 5), y = c(-6, 5))
+```
 
 ## Dangers of overfitting ⚠️ `r hexes("yardstick")`
 

--- a/slides/setup.R
+++ b/slides/setup.R
@@ -1,5 +1,6 @@
 # packages needed to make the slides, but not needed for participants
-# dev_pkgs <- c("countdown", "forcats", "hadley/emo", "sessioninfo", "svglite")
+# dev_pkgs <-
+#   c("countdown", "forcats", "hadley/emo", "sessioninfo", "svglite", "kernlab")
 # pak::pak(dev_pkgs)
 
 #   ----------------------------------------------------------------------


### PR DESCRIPTION
A little bit of developer complexity for the sake of participant simplicity. Given that we're already teaching a binary classification problem, I thought it'd be nice if the colors matched the ones that participants would expect with the example plot, i.e. green and tan mean two levels of an outcome variable.

Source for the original image: https://github.com/topepo/2022-nyr-workshop/blob/19266c8254a7c53b7a29bf424e4cafcbab91d5b5/5-tuning.Rmd#L173C1-L276C4