### PR TITLE
transition to georgia data in introductory workshop

### DIFF
--- a/classwork/intro-02-classwork.qmd
+++ b/classwork/intro-02-classwork.qmd
@@ -7,13 +7,13 @@ editor_options:
 
 We recommend restarting R between each slide deck!
 
-## Data on forests in Washington
+## Data on forests in Georgia
 
 ```{r}
 library(tidymodels)
 library(forested)
 
-forested
+forested_ga
 ```
 
 ## Your turn
@@ -25,7 +25,7 @@ When is a good time to split your data?
 ```{r}
 set.seed(123)
 
-forested_split <- initial_split(forested)
+forested_split <- initial_split(forested_ga)
 forested_split
 ```
 

--- a/classwork/intro-03-classwork.qmd
+++ b/classwork/intro-03-classwork.qmd
@@ -16,7 +16,7 @@ library(tidymodels)
 library(forested)
 
 set.seed(123)
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 ```

--- a/classwork/intro-04-classwork.qmd
+++ b/classwork/intro-04-classwork.qmd
@@ -16,7 +16,7 @@ library(tidymodels)
 library(forested)
 
 set.seed(123)
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 

--- a/classwork/intro-05-classwork.qmd
+++ b/classwork/intro-05-classwork.qmd
@@ -16,7 +16,7 @@ library(tidymodels)
 library(forested)
 
 set.seed(123)
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 

--- a/classwork/intro-extra-recipes-classwork.qmd
+++ b/classwork/intro-extra-recipes-classwork.qmd
@@ -16,7 +16,7 @@ library(tidymodels)
 library(forested)
 
 set.seed(123)
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 ```

--- a/classwork/intro-extra-workflowsets-classwork.qmd
+++ b/classwork/intro-extra-workflowsets-classwork.qmd
@@ -16,7 +16,7 @@ library(tidymodels)
 library(forested)
 
 set.seed(123)
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 

--- a/slides/intro-02-data-budget.qmd
+++ b/slides/intro-02-data-budget.qmd
@@ -67,7 +67,7 @@ Credit: <https://www.svgrepo.com/svg/67614/forest>
 :::
 
 :::notes
-- Those nominal variables are classifications similar to "forested" but from other agencies. e.g. `land_type` is from the European Space Agency, and is a remotely-sensed 3-class distribution based on predictions for how the land is used.
+- Those nominal variables are classifications similar to "forested" but from other agencies. e.g. `land_type` is from the European Space Agency, and is a remotely-sensed 3-class distribution based on predictions for how the land is used. (The data also includes a `county` variable, which is not itself from a model.)
 :::
 
 ## Checklist for predictors

--- a/slides/intro-02-data-budget.qmd
+++ b/slides/intro-02-data-budget.qmd
@@ -26,14 +26,14 @@ knitr:
 ##  {background-image="https://media.giphy.com/media/Lr3UeH9tYu3qJtsSUg/giphy.gif" background-size="40%"}
 
 
-## Data on forests in Washington
+## Data on forests in Georgia
 
 ::: columns
 ::: {.column width="60%"}
 -   The U.S. Forest Service maintains ML models to predict whether a plot of land is "forested."
 -   This classification is important for all sorts of research, legislation, and land management purposes.
 -  Plots are typically remeasured every 10 years and this dataset contains the most recent measurement per plot.
--   Type `?forested` to learn more about this dataset, including references.
+-   Type `?forested_ga` to learn more about this dataset, including references.
 :::
 
 ::: {.column width="40%"}
@@ -46,11 +46,11 @@ knitr:
 Credit: <https://www.svgrepo.com/svg/251793/forest-mountain>
 :::
 
-## Data on forests in Washington
+## Data on forests in Georgia
 
 ::: columns
 ::: {.column width="70%"}
--   `N = 7,107` plots of land, one from each of 7,107 6000-acre hexagons in WA.
+-   `N = `r nrow(forested_ga)`` plots of land, one from each of `r nrow(forested_ga)` 6000-acre hexagons in Georgia.
 -   A nominal outcome, `forested`, with levels `"Yes"` and `"No"`, measured "on-the-ground."
 -   18 remotely-sensed and easily-accessible predictors:
      - **numeric** variables based on weather and topography.
@@ -82,13 +82,13 @@ Credit: <https://www.svgrepo.com/svg/67614/forest>
 - re: ethics -- what issues might arise from releasing the true `lat` and `lon`? In reality, these `lat` and `lon` are slightly jittered to help ensure trust with landowners who allow surveyers to come take measurements.
 :::
 
-## Data on forests in Washington
+## Data on forests in Georgia
 
 ```{r forested-print}
 library(tidymodels)
 library(forested)
 
-forested
+forested_ga
 ```
 
 
@@ -166,7 +166,7 @@ countdown::countdown(minutes = 3, id = "when-to-split")
 
 ```{r forested-split}
 set.seed(123)
-forested_split <- initial_split(forested)
+forested_split <- initial_split(forested_ga)
 forested_split
 ```
 
@@ -221,7 +221,7 @@ countdown::countdown(minutes = 5, id = "try-splitting")
 
 ```{r forested-split-prop}
 set.seed(123)
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 

--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -76,7 +76,7 @@ library(forested)
 
 set.seed(123)
 
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 ```

--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -31,7 +31,7 @@ library(tidymodels)
 library(forested)
 
 set.seed(123)
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 

--- a/slides/intro-05-tuning-models.qmd
+++ b/slides/intro-05-tuning-models.qmd
@@ -30,7 +30,7 @@ library(tidymodels)
 library(forested)
 
 set.seed(123)
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 

--- a/slides/intro-extra-recipes.qmd
+++ b/slides/intro-extra-recipes.qmd
@@ -33,7 +33,7 @@ library(tidymodels)
 library(forested)
 
 set.seed(123)
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 

--- a/slides/intro-extra-workflowsets.qmd
+++ b/slides/intro-extra-workflowsets.qmd
@@ -30,7 +30,7 @@ library(tidymodels)
 library(forested)
 
 set.seed(123)
-forested_split <- initial_split(forested, prop = 0.8)
+forested_split <- initial_split(forested_ga, prop = 0.8)
 forested_train <- training(forested_split)
 forested_test <- testing(forested_split)
 

--- a/slides/setup.R
+++ b/slides/setup.R
@@ -25,6 +25,7 @@ knitr::opts_chunk$set(
 
 # devtools::install_github("gadenbuie/countdown")
 library(countdown)
+library(forested)
 library(ggplot2)
 theme_set(theme_bw())
 options(


### PR DESCRIPTION
A first pass; just the most basic changes. Will need to make a pass through and make sure that EDA and modeling concepts are still demonstrated as intended.

Prompt:

> This repository contains workshop materials for two tidymodels workshops, intro and advanced.
> 
> I'm working on the introductory workshop. I just made changes to the underlying data from the forested package:
> 
> * The first version of the package just had data from Washington, called `forested`. The second release of the package also includes data from Georgia. The `forested` data is the same as it was, and now is aliased as `forested_wa`. The data from Georgia is called `forested_ga`. The Georgia data has the same structure, except is missing the `northness` variable due to issues with the source raster. `forested_ga` also includes a new variable `county`.
>
>* `forested` and its alias `forested_wa` gained a new variable, `county`.
>
> forested is my own package. I have this developmental version installed; it will be on CRAN by the time participants see it.
> 
> I would like to transition the introductory workshop to use the `forested_ga` data instead of the `forested` data. Could you make that happen? Update the slides starting with `intro-` in `slides/` as well as `classwork/` (if needed). Note that the package, the dataset, and the target variable were called `forested`, so you can't just find and replace on that. Both the package and target variable are still called `forested`.