### PR TITLE
Tweak rpart plot

### DIFF
--- a/slides/annotations.qmd
+++ b/slides/annotations.qmd
@@ -85,6 +85,37 @@ cat(paste0("set.seed(", sample.int(10000, 5), ")", collapse = "\n"))
 
 <hr size="5">
 
+## Understand your model
+
+We've abbreviated the code necessary to make the exact plot on the previous slide. The full code is:
+
+```r
+library(rpart.plot)
+split_fun <- function(x, labs, digits, varlen, faclen) {
+  for (i in 1:length(labs)) {
+    if (grepl(",", labs[i])) {
+      parts <- strsplit(labs[i], ",")[[1]]
+      parts <- trimws(parts)
+      if (length(parts) > 5) {
+        parts <- c(parts[1:5], "...")
+      }
+      labs[i] <- paste(parts, collapse = ", ")
+    }
+    labs[i] <- paste(strwrap(labs[i], width = 15), collapse = "\n")
+  }
+  labs
+}
+
+tree_fit |>
+  extract_fit_engine() |>
+  rpart.plot(
+    roundint = FALSE,
+    type = 3,
+    clip.right.labs = FALSE,
+    split.fun = split_fun
+  )
+```
+
 # Introduction 3 - What Makes A Model?
 
 ## What is wrong with this? 

--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -579,9 +579,30 @@ How do you **understand** your new `tree_fit` model?
 #| echo: false
 #| fig-align: center
 library(rpart.plot)
+split_fun <- function(x, labs, digits, varlen, faclen) {
+  for (i in 1:length(labs)) {
+    if (grepl(",", labs[i])) {
+      parts <- strsplit(labs[i], ",")[[1]]
+      parts <- trimws(parts)
+
+      if (length(parts) > 5) {
+        parts <- c(parts[1:5], "...")
+      }
+
+      labs[i] <- paste(parts, collapse = ", ")
+    }
+    labs[i] <- paste(strwrap(labs[i], width = 15), collapse = "\n")
+  }
+  labs
+}
 tree_fit |>
   extract_fit_engine() |>
-  rpart.plot(roundint = FALSE)
+  rpart.plot(
+    roundint = FALSE,
+    type = 3,
+    clip.right.labs = FALSE,
+    split.fun = split_fun
+  )
 ```
 
 ## Understand your model `r hexes("parsnip", "workflows")`

--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -605,7 +605,7 @@ tree_fit |>
   )
 ```
 
-## Understand your model `r hexes("parsnip", "workflows")`
+## Understand your model `r hexes("parsnip", "workflows")` {.annotation}
 
 How do you **understand** your new `tree_fit` model?
 
@@ -614,7 +614,7 @@ How do you **understand** your new `tree_fit` model?
 library(rpart.plot)
 tree_fit |>
   extract_fit_engine() |>
-  rpart.plot(roundint = FALSE)
+  rpart.plot()
 ```
 
 You can `extract_*()` several components of your fitted workflow.


### PR DESCRIPTION
Max mentioned that the many levels of the county factor don't work well in the rpart decision tree.

If we want to tweak the plot (rather than say the number of factor levels in the data or the model choice), we could go with something like this. 
If we want to show people `split_fun()`, we could add it to the annotations.

<img width="1512" height="771" alt="Screenshot 2025-08-26 at 12 42 01" src="https://github.com/user-attachments/assets/d238e3b9-cd64-4f78-8a41-0989b30b3e2f" />
