### PR TITLE
intro: rotate train/test split diagram

### DIFF
--- a/slides/intro-02-data-budget.qmd
+++ b/slides/intro-02-data-budget.qmd
@@ -109,31 +109,33 @@ Do not 🚫 use the test set during training.
 
 ```{r test-train-split}
 #| echo: false
-#| fig.width: 12
-#| fig.height: 3
+#| fig.width: 5
+#| fig.height: 6
 #| 
 set.seed(123)
 library(forcats)
-one_split <- tibble(x = 1:30) |> 
+
+one_split <- tibble(x = 1:10) |> 
   initial_split() |> 
   tidy() |> 
-  add_row(Row = 1:30, Data = "Original") |> 
+  add_row(Row = 1:10, Data = "Original") |> 
   mutate(Data = case_when(
     Data == "Analysis" ~ "Training",
     Data == "Assessment" ~ "Testing",
     TRUE ~ Data
   )) |> 
   mutate(Data = factor(Data, levels = c("Original", "Training", "Testing")))
+
 all_split <-
-  ggplot(one_split, aes(x = Row, y = fct_rev(Data), fill = Data)) + 
-  geom_tile(color = "white",
-            linewidth = 1) + 
+  ggplot(one_split, aes(x = Data, y = Row, fill = Data)) + 
+  geom_tile(color = "white") + 
   scale_fill_manual(values = splits_pal, guide = "none") +
   theme_minimal() +
-  theme(axis.text.y = element_text(size = rel(2)),
-        axis.text.x = element_blank(),
+  theme(axis.text.x = element_text(size = rel(2), angle = -45, hjust = 1),
+        axis.text.y = element_blank(),
         legend.position = "top",
         panel.grid = element_blank()) +
+  scale_x_discrete(position = "top") +
   coord_equal(ratio = 1) +
   labs(x = NULL, y = NULL)
 all_split


### PR DESCRIPTION
Closes #409. Here's the result:

<img width="2062" height="1188" alt="Screenshot 2025-09-02 at 4 12 39 PM" src="https://github.com/user-attachments/assets/1493ff36-f98b-4945-8982-843d6435cce8" />

