### PR TITLE
intro: transition "model" to "model type"

### DIFF
--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -56,7 +56,7 @@ countdown::countdown(minutes = 3, id = "how-to-fit-linear-model")
 
 ::: columns
 ::: {.column width="60%"}
--   Choose a [model]{.underline}
+-   Choose a [model type]{.underline}
 -   Specify an engine
 -   Set the mode
 :::
@@ -94,7 +94,7 @@ Models have default engines
 
 ::: columns
 ::: {.column width="60%"}
--   Choose a model
+-   Choose a model type
 -   Specify an [engine]{.underline}
 -   Set the mode
 :::
@@ -123,7 +123,7 @@ logistic_reg() |>
 
 ::: columns
 ::: {.column width="60%"}
--   Choose a model
+-   Choose a model type
 -   Specify an engine
 -   Set the [mode]{.underline}
 :::
@@ -169,7 +169,7 @@ All available models are listed at <https://www.tidymodels.org/find/parsnip/>
 
 ::: columns
 ::: {.column width="60%"}
--   Choose a [model]{.underline}
+-   Choose a [model type]{.underline}
 -   Specify an [engine]{.underline}
 -   Set the [mode]{.underline}
 :::


### PR DESCRIPTION
Closes #415.

Updates the slide bulleted lists to:
- Change "Choose a model" to "Choose a model type"
- Update underlining from "model" to "type" where applicable

Generated with [Claude Code](https://claude.ai/code)