### PR TITLE
intro: update reference to advanced workshop

### DIFF
--- a/slides/intro-03-what-makes-a-model.qmd
+++ b/slides/intro-03-what-makes-a-model.qmd
@@ -449,7 +449,7 @@ knitr::include_graphics("images/bad_workflow.png")
 
 . . .
 
--   You can use other preprocessors besides formulas (more on feature engineering in Advanced tidymodels!)
+-   You can use other preprocessors besides formulas (more on this in _Getting More Out of Feature Engineering and Tuning for Machine Learning_)
 
 . . .
 


### PR DESCRIPTION
Updates the parenthetical reference to the advanced workshop in the intro slides.

Fixes #417

Generated with [Claude Code](https://claude.ai/code)