### PR TITLE
add "Your turn" to derive accuracy

### DIFF
--- a/classwork/intro-04-classwork.qmd
+++ b/classwork/intro-04-classwork.qmd
@@ -44,6 +44,19 @@ augment(forested_fit, new_data = forested_train) |>
   autoplot(type = "heatmap")
 ```
 
+## Your turn
+
+What's the simplest way you might combine TP, TN, FP, and FN to describe how often this model is "right" in one number?
+
+```{r}
+#>                    Observed
+#>                     Yes  No
+#> Predicted  Yes       TP  FP
+#>             No       FN  TN
+```
+
+## Metrics for model performance
+
 using the same interface we can calculate metrics
 
 ```{r}

--- a/classwork/intro-04-classwork.qmd
+++ b/classwork/intro-04-classwork.qmd
@@ -46,7 +46,7 @@ augment(forested_fit, new_data = forested_train) |>
 
 ## Your turn
 
-What's the simplest way you might combine TP, TN, FP, and FN to describe how often this model is "right" in one number?
+How would you combine TP, TN, FP, and FN into one number to describe how often the model is correct?
 
 ```{r}
 #>                    Observed

--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -69,7 +69,7 @@ augment(forested_fit, new_data = forested_train) |>
 
 <br>
 
-*What's the simplest way you might combine TP, TN, FP, and FN to describe how often this model is "right" in one number?*
+*How would you combine TP, TN, FP, and FN into one number to describe how often the model is correct?*
 
 :::::: {.columns}
 ::: {.column}

--- a/slides/intro-04-evaluating-models.qmd
+++ b/slides/intro-04-evaluating-models.qmd
@@ -63,6 +63,26 @@ augment(forested_fit, new_data = forested_train) |>
   autoplot(type = "heatmap")
 ```
 
+## Your turn {transition="slide-in"}
+
+![](images/parsnip-flagger.jpg){.absolute top="0" right="0" width="150" height="150"}
+
+<br>
+
+*What's the simplest way you might combine TP, TN, FP, and FN to describe how often this model is "right" in one number?*
+
+:::::: {.columns}
+::: {.column}
+![](images/confusion-matrix.png){width=60%}
+:::
+::: {.column}
+```{r ex-derive-accuracy}
+#| echo: false
+countdown::countdown(minutes = 5, id = "derive-accuracy")
+```
+:::
+:::
+
 ## Metrics for model performance `r hexes("yardstick")`
 
 ::: columns


### PR DESCRIPTION
Adds an exercise on deriving accuracy from TP/FP/FN/TN. 

I considered adding similar ones for specificity/sensitivity, but that seemed too soon after the existing one, and I also considered adding one pre-ROC but that seems too far-fetched.

<img width="1873" height="1072" alt="Screenshot 2025-09-04 at 9 12 43 AM" src="https://github.com/user-attachments/assets/9d9a264c-d5a6-4f80-8989-ca37a73ff5e3" />

Vibe check, @hfrick—is the difficulty of this one calibrated reasonably? Is this helpful for understanding?